### PR TITLE
Fix for Incorrect Attribute Name in Documentation

### DIFF
--- a/doc/user_manual.html
+++ b/doc/user_manual.html
@@ -2439,7 +2439,7 @@ CELLSPACING=0><TR><TD BGCOLOR=black COLSPAN="3"><TABLE CELLSPACING="1" CELLPADDI
 </TABLE></TD></TR>
 <TR><TD BGCOLOR=black COLSPAN="1"><TABLE CELLSPACING="1" CELLPADDING=0 BORDER=0><TR><TD>
 </TD></TR>
-</TABLE></TD><TD><TABLE BORDER=0 CELLPADDING="1" CELLSPACING=0><TR><TD><PRE CLASS="verbatim">&lt;dyn_variable name="array3_value" json="field.array[3].value"/&gt;
+</TABLE></TD><TD><TABLE BORDER=0 CELLPADDING="1" CELLSPACING=0><TR><TD><PRE CLASS="verbatim">&lt;dyn_variable name="array3_value" jsonpath="field.array[3].value"/&gt;
 </PRE></TD></TR>
 </TABLE></TD><TD BGCOLOR=black COLSPAN="1"><TABLE CELLSPACING="1" CELLPADDING=0 BORDER=0><TR><TD>
 </TD></TR>
@@ -2455,7 +2455,7 @@ CELLSPACING=0><TR><TD BGCOLOR=black COLSPAN="3"><TABLE CELLSPACING="1" CELLPADDI
 </TABLE></TD></TR>
 <TR><TD BGCOLOR=black COLSPAN="1"><TABLE CELLSPACING="1" CELLPADDING=0 BORDER=0><TR><TD>
 </TD></TR>
-</TABLE></TD><TD><TABLE BORDER=0 CELLPADDING="1" CELLSPACING=0><TR><TD><PRE CLASS="verbatim">&lt;dyn_variable name="myvar" json="field.array[?name=bar].value"/&gt;
+</TABLE></TD><TD><TABLE BORDER=0 CELLPADDING="1" CELLSPACING=0><TR><TD><PRE CLASS="verbatim">&lt;dyn_variable name="myvar" jsonpath="field.array[?name=bar].value"/&gt;
 </PRE></TD></TR>
 </TABLE></TD><TD BGCOLOR=black COLSPAN="1"><TABLE CELLSPACING="1" CELLPADDING=0 BORDER=0><TR><TD>
 </TD></TR>

--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -1969,12 +1969,12 @@ Tsung implements a (very) limited subset of JSONPath as defined here \url{http:/
 To utilize jsonpath expression, use a \varname{jsonpath} attribute when
 defining the dyn\_variable, instead of \varname{regexp}, like:
 \begin{Verbatim}
-<dyn_variable name="array3_value" json="field.array[3].value"/>
+<dyn_variable name="array3_value" jsonpath="field.array[3].value"/>
 \end{Verbatim}
 
 You can also use expressions \userinput{Key=Val}, e.g.:
 \begin{Verbatim}
-<dyn_variable name="myvar" json="field.array[?name=bar].value"/>
+<dyn_variable name="myvar" jsonpath="field.array[?name=bar].value"/>
 \end{Verbatim}
 
 \paragraph{PostgreSQL}


### PR DESCRIPTION
The documentation incorrectly uses the "json" attribute in its examples. These examples should use the "jsonpath" attribute. Here is a fix for these examples.
