### PR TITLE
adding missing autoconf as a build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: tsung
 Section: net
 Priority: optional
 Maintainer: Nicolas Niclausse <nicolas.niclausse@niclux.org>
-Build-Depends: debhelper (>= 4.0.0), erlang-nox (>= 10.b.5-1) , docbook-utils, erlang-src, erlang-dev
+Build-Depends: debhelper (>= 4.0.0), erlang-nox (>= 10.b.5-1) , docbook-utils, erlang-src, erlang-dev, autoconf
 Standards-Version: 3.6.0
 
 Package: tsung


### PR DESCRIPTION
autoconf is needed to build the .deb on debian squeeze. Adding it to build dependencies
