### PR TITLE
Add wildcard support for jsonpath

### DIFF
--- a/src/test/ts_test_search.erl
+++ b/src/test/ts_test_search.erl
@@ -56,6 +56,11 @@ parse_dyn_var_jsonpath5_test() ->
     JSONPath = "titi[?status=OK].val",
     ?assertEqual([{'myvar',[42,48]}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))).
 
+parse_dyn_var_jsonpath6_test() ->
+    myset_env(),
+    Data="\r\n\r\n{\"titi\": [{\"val\": 123, \"name\": \"foo\"}, {\"val\": 42, \"name\": \"bar\"}]}",
+    JSONPath = "titi[*].val",
+    ?assertEqual([{'myvar',[123,42]}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath_int_test() ->
     myset_env(),

--- a/src/tsung/ts_utils.erl
+++ b/src/tsung/ts_utils.erl
@@ -749,6 +749,10 @@ json_get_bin([Key|Keys],undefined) ->
 json_get_bin([N|Keys],L) when is_integer(N), N =< length(L) ->
     Val =  lists:nth(N,L),
     json_get_bin(Keys,Val);
+json_get_bin([N|Keys], L) when N =:= <<"*">>, is_list(L) ->
+    lists:map(fun(A) -> json_get_bin(Keys,A) end, L);
+json_get_bin([N|Keys],Val) when N =:= <<"*">> ->
+    json_get_bin(Keys,Val);
 json_get_bin([<<"?",Expr/binary>> | Keys],L) when  is_list(L) ->
     case string:tokens(binary_to_list(Expr),"=") of
         [Key,Val] ->


### PR DESCRIPTION
Such as titi[*].val to find all the val's of elements in titi.
