### PR TITLE
Let change_type have dynvars in Host and Port attributes

### DIFF
--- a/src/tsung/ts_client.erl
+++ b/src/tsung/ts_client.erl
@@ -430,6 +430,8 @@ handle_next_action(State) ->
         {change_type, NewCType, Server, Port, PType, Store, Restore} ->
             ?DebugF("Change client type, use: ~p ~p~n",[NewCType, [Server , Port, PType, Store, Restore]]),
             DynData=State#state_rcv.dyndata,
+            NewPort = ts_search:subst(Port,DynData#dyndata.dynvars),
+            NewServer = ts_search:subst(Server,DynData#dyndata.dynvars),
             case Store of
                 true -> % keep state
                     put({state, State#state_rcv.clienttype} , {State#state_rcv.socket,State#state_rcv.session,DynData#dyndata.proto});
@@ -445,7 +447,7 @@ handle_next_action(State) ->
                          {none,NewCType:new_session(),DD#dyndata.proto}
                  end,
             NewDynData=DynData#dyndata{proto=ProtoDynData},
-            NewState=State#state_rcv{session=Session,socket=Socket,count=Count,clienttype=NewCType,protocol=PType,port=Port,host=Server,dyndata=NewDynData},
+            NewState=State#state_rcv{session=Session,socket=Socket,count=Count,clienttype=NewCType,protocol=PType,port=NewPort,host=NewServer,dyndata=NewDynData},
             handle_next_action(NewState);
         {set_option, undefined, rate_limit, {Rate, Burst}} ->
             ?LOGF("Set rate limits for client: rate=~p, burst=~p~n",[Rate,Burst],?DEB),

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -553,7 +553,7 @@ parse( #xmlElement{name=change_type, attributes=Attrs},
 
     CType   = getAttr(atom, Attrs, new_type),
     Server  = getAttr(string, Attrs, host),
-    Port    = getAttr(integer, Attrs, port),
+    Port    = getAttr(string, Attrs, port),
     Store   = getAttr(atom, Attrs, store, false),
     Restore = getAttr(atom, Attrs, restore, false),
     PType   = set_net_type(getAttr(Attrs, server_type)),

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -124,8 +124,8 @@ repeat | if | change_type | foreach | set_option)*>
 <!ELEMENT change_type EMPTY>
 <!ATTLIST change_type
      new_type         (ts_jabber | ts_http | ts_raw | ts_pgsql | ts_ldap | ts_webdav |ts_mysql| ts_fs | ts_shell|ts_job) #REQUIRED
-     host NMTOKEN #REQUIRED
-     port NMTOKEN #REQUIRED
+     host CDATA #REQUIRED
+     port CDATA #REQUIRED
      server_type NMTOKEN #REQUIRED
      store  ( true | false ) "false"
      restore ( true | false ) "false"


### PR DESCRIPTION
It was very useful for me since change_type is dynamic by nature.
In my case I need to establish connection to host:port received from previous requests.
