### PR TITLE
Respect current python executable in environment

### DIFF
--- a/src/tsung-plotter/tsplot.py.in
+++ b/src/tsung-plotter/tsplot.py.in
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 # -*- Mode: python -*-
 # -*- coding: utf-8 -*-
 


### PR DESCRIPTION
When using e.g. virtualenvs, just setting to /usr/bin/python won't work.
