### PR TITLE
Trim white space from Transfer-Encoding header

### DIFF
--- a/src/tsung/ts_http_common.erl
+++ b/src/tsung/ts_http_common.erl
@@ -607,15 +607,13 @@ parse_line("connection: close"++_Tail, Http, _Host)->
 parse_line("content-encoding: "++Tail, Http=#http{compressed={Prev,_}}, _Host)->
     ?DebugF("content encoding:~p ~n",[Tail]),
     Http#http{compressed={list_to_atom(Tail),Prev}};
-parse_line("transfer-encoding:"++[H|Tail], Http, _Host)->
-    ?DebugF("~p transfer encoding~n",[[H]++Tail]),
-    case Tail of
+parse_line("transfer-encoding:"++Tail, Http, _Host)->
+    ?DebugF("~p transfer encoding~n",[Tail]),
+    case string:strip(Tail) of
         [C|"hunked"++_] when C == $C; C == $c ->
             Http#http{chunk_toread=0};
-        "hunked"++_  when H == $C; H == $c->
-            Http#http{chunk_toread=0};
         _ ->
-            ?LOGF("Unknown transfer encoding ~p~n",[[H]++Tail],?NOTICE),
+            ?LOGF("Unknown transfer encoding ~p~n",[Tail],?NOTICE),
             Http
     end;
 parse_line("set-cookie: "++Tail, Http=#http{cookie=PrevCookies}, Host)->


### PR DESCRIPTION
While writing a few Tsung tests I had an issue with the Transfer-Encoding header value. I was receiving the following error:

=INFO REPORT==== 6-Nov-2012::14:00:13 ===
      ts_http_common:(5:<0.109.0>) Unknown transfer encoding "  chunked"

=INFO REPORT==== 6-Nov-2012::14:00:13 ===
      ts_http_common:(3:<0.109.0>) Error: HTTP Body (39)> Content-Length (0) !

which resulted from the following header:

Transfer-Encoding:  chunked

(Observe the extra spaces before the header value.)

I have attached my attempt at patching Tsung by whitespace trimming the value before matching the "chunked" key.
