### PR TITLE
fix bug for get online/offline users when use with user-defined users

### DIFF
--- a/src/tsung_controller/ts_user_server.erl
+++ b/src/tsung_controller/ts_user_server.erl
@@ -308,7 +308,7 @@ handle_call( {get_online, Id}, _From, State=#state{ online     = Online,
             {reply, {error, no_online}, State};
         {ok, {User,Pwd}} ->
             ?DebugF("Choose user defined online user ~p for ~p ~n",[User, Id]),
-            {reply, {ok, User}, State#state{last_online={User,Pwd}}};
+            {reply, {ok, {User,Pwd}}, State#state{last_online={User,Pwd}}};
         {ok, Next} ->
             ?DebugF("Choose online user ~p for ~p ~n",[Next, Id]),
             {reply, {ok, Next}, State#state{last_online=Next}}


### PR DESCRIPTION
with user defined users (with something like this<xmpp_authenticate username="%%_username%%" passwd="%%_password%%" />),  when get online/offline users, tsung will select a user like "tsung%%_username%%" (here "tsung" is config by jabber option: username)
