### PR TITLE
Fix the bug TSUN-232

### DIFF
--- a/src/tsung/ts_bosh.erl
+++ b/src/tsung/ts_bosh.erl
@@ -288,6 +288,7 @@ do_connect(#state{type = Type, host = Host, path = Path, parent_pid = ParentPid}
     NewState3#state{rid = Rid +1,
                     open = [],
                     sid = get_attr(Attrs, sid),
+                    session_state = normal,
                     max_requests = 2
                    }.
 


### PR DESCRIPTION
In ts_bosh:do_connect(), the code that set session_state to normal is missed so there is no empty request sent in do_receive_httpresponse.
