### PR TITLE
Update ts_jabber:username to handle user defined in csv properly

### DIFF
--- a/src/tsung/ts_jabber.erl
+++ b/src/tsung/ts_jabber.erl
@@ -314,6 +314,8 @@ updatejab([_|Rest], Param)->
 %%% Func: username/2
 %%% Generate the username given a prefix and id
 %%%----------------------------------------------------------------------
+username({_,_}, DestId) ->
+    DestId;
 username(Prefix, DestId) when is_integer(DestId)->
     Prefix ++ integer_to_list(DestId);
 username(Prefix, DestId) ->


### PR DESCRIPTION
In case that username option for ts_jabber is not defined and user defined in csv, ts_jabber:username need to ignore the prefix.
