### PR TITLE
Fix typo in doc

### DIFF
--- a/doc/user_manual.tex
+++ b/doc/user_manual.tex
@@ -2160,7 +2160,7 @@ attribute to identify each file:
  <option name="file_server" id='random' value="/tmp/randomnumbers.csv"></option>
 \end{Verbatim}
 
-Now you can build you own function to use it, for example, create a
+Now you can build your own function to use it, for example, create a
 file called \file{readcsv.erl}:
 
 \begin{Verbatim}


### PR DESCRIPTION
Fix little typo, replace _you own_ by _your own_
