### PR TITLE
fix for TSUN-253

### DIFF
--- a/doc/user_manual.html
+++ b/doc/user_manual.html
@@ -56,7 +56,6 @@ h4          {font-family:Sans-Serif; font-size:100%; font-weight:bold; color:#00
 h5          {font-family:Sans-Serif; font-size:100%; font-weight:bold; color:#000000;  background-color:#ffffff; margin-bottom: 0;}
 form        {margin-bottom:-5px;}
 textarea    {color:#333333;  background-color:#ffffff; width:90%;}
-table       {font-size:90%;}
 dl,ul,ol    {margin-top: 2pt; margin-bottom: 2pt;}
 tt, pre     {font-family:monospace; color:#666666; background-color:#ffffff;}
 pre {


### PR DESCRIPTION
Fix for issue https://support.process-one.net/browse/TSUN-253
Removed css entry: 

```
table: {font-size: 90%}
```

so it makes code blocks as much readable as in PDF version.

Great manual, btw, but I had to zoom over 150% or broke my eyes while reading code examples.
