### PR TITLE
add bidi attribute to change_type

### DIFF
--- a/src/tsung/ts_client.erl
+++ b/src/tsung/ts_client.erl
@@ -417,7 +417,7 @@ handle_next_action(State) ->
             ctrl_struct(CtrlData,State,Count);
         Request=#ts_request{} ->
             handle_next_request(Request, State);
-        {change_type, NewCType, Server, Port, PType, Store, Restore} ->
+        {change_type, NewCType, Server, Port, PType, Store, Restore, Bidi} ->
             ?DebugF("Change client type, use: ~p ~p~n",[NewCType, [Server , Port, PType, Store, Restore]]),
             DynVars   = State#state_rcv.dynvars,
             NewPort   = case ts_search:subst(Port,DynVars) of
@@ -440,7 +440,8 @@ handle_next_action(State) ->
                      {_,_} -> % nothing to restore, or no restore asked, set new session
                          {none,NewCType:new_session()}
                  end,
-            NewState=State#state_rcv{session=Session,socket=Socket,count=Count,clienttype=NewCType,protocol=PType,port=NewPort,host=NewServer},
+            NewState=State#state_rcv{session=Session,socket=Socket,count=Count,clienttype=NewCType,protocol=PType,
+                                     port=NewPort,host=NewServer,bidi=Bidi},
             handle_next_action(NewState);
         {set_option, undefined, rate_limit, {Rate, Burst}} ->
             ?LOGF("Set rate limits for client: rate=~p, burst=~p~n",[Rate,Burst],?DEB),

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -569,11 +569,12 @@ parse( #xmlElement{name=change_type, attributes=Attrs},
     Store   = getAttr(atom, Attrs, store, false),
     Restore = getAttr(atom, Attrs, restore, false),
     PType   = set_net_type(getAttr(Attrs, server_type)),
+    Bidi    = getAttr(atom, Attrs, bidi, false),
     SessType=case Conf#config.main_sess_type == CType of
                  false -> CurS#session.type;
                  true  -> CType % back to the main type
              end,
-    ets:insert(Tab,{{CurS#session.id, Id+1}, {change_type, CType, Server, Port, PType, Store, Restore}}),
+    ets:insert(Tab,{{CurS#session.id, Id+1}, {change_type, CType, Server, Port, PType, Store, Restore, Bidi}}),
     ?LOGF("Parse change_type (~p) ~p:~p:~p:~p ~n",[CType, Server,Port,PType,Id],?NOTICE),
     Conf#config{main_sess_type=SessType, curid=Id+1,
                 sessions=[CurS#session{type=CType}|Other] };

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -136,6 +136,7 @@ repeat | if | change_type | foreach | set_option | interaction )*>
      server_type NMTOKEN #REQUIRED
      store  ( true | false ) "false"
      restore ( true | false ) "false"
+     bidi ( true | false ) "false"
     >
 
 <!ELEMENT request ( match*, dyn_variable*, ( http | jabber | raw |


### PR DESCRIPTION
when a non-bidi protocol used with a bidi protocol, if change_type doesn't change the bidi attribute of #state_rcv,
it may cause problems.

For the following config:
<session name="activity_browse" probability="100" type="ts_http">
        <change_type new_type="ts_websocket" host="127.0.0.1" port="8080" server_type="tcp" restore="true" store="true" />
        <request subst="true">
             <websocket type="connect" path="/chat"></websocket>
        </request>
        <thinktime value="15" random="true"/>
...
</session>

right after the 'connect' request finished, if the server send some data to the client, it will cause the connection to be closed.
