### PR TITLE
fix websocket close issue: we should wait a close response

### DIFF
--- a/src/lib/websocket.erl
+++ b/src/lib/websocket.erl
@@ -93,7 +93,12 @@ encode_text(Data) ->
     encode(Data, ?OP_TEXT).
 
 encode_close(Reason) ->
-    encode(Reason, ?OP_CLOSE).
+    %% According RFC6455, we shoud add a status code for close frame,
+    %% check here: http://tools.ietf.org/html/rfc6455#section-7.4,
+    %% we add a normal closure status code 1000 here.
+    StatusCode = <<3, 232>>,
+    Data = <<StatusCode/binary, Reason/binary>>,
+    encode(Data, ?OP_CLOSE).
 
 encode(Data, Opcode) ->
     Key = crypto:rand_bytes(4),

--- a/src/tsung_controller/ts_config_websocket.erl
+++ b/src/tsung_controller/ts_config_websocket.erl
@@ -59,6 +59,9 @@ parse_config(Element = #xmlElement{name = websocket},
     Ack = case Type of
               connect ->
                   parse;
+              %% we should wait a close response from the server
+              close ->
+                  ack;
               _ ->
                   no_ack
           end,


### PR DESCRIPTION
when user config a websocket connect request after a close request, websocket will receive the last close response as the response of connect request, this will cause parse error.
