### PR TITLE
Modifications to AMQP to optionally specify the payload and allow substitutions on the payload.

### DIFF
--- a/examples/amqp.xml.in
+++ b/examples/amqp.xml.in
@@ -40,11 +40,11 @@
             <for from="1" to="200" incr="1" var="loops">
                 <for from="1" to="10000" incr="1" var="counter">
                     <transaction name="publish">
-                        <!-- specify synthetic_payload_size to have tsung generate a payload for you -->
+                        <!-- specify payload_size to have tsung generate a payload for you -->
                         <request>
-                            <amqp type="basic.publish" exchange="test_exchange" routing_key="4.queue_lb" persistent="true" synthetic_payload_size="100"></amqp>
+                            <amqp type="basic.publish" exchange="test_exchange" routing_key="4.queue_lb" persistent="true" payload_size="100"></amqp>
                         </request>
-                        <!-- substitutions are supported on the payload.  This will override synthetic_payload_size. -->
+                        <!-- substitutions are supported on the payload.  Payload will override payload_size. -->
                         <request>
                             <amqp type="basic.publish" exchange="test_exchange" routing_key="4.queue_lb" persistent="true" payload="Test Payload"></amqp>
                         </request>

--- a/include/ts_amqp.hrl
+++ b/include/ts_amqp.hrl
@@ -30,7 +30,7 @@
           prefetch_count,
           persistent,
           payload,
-          synthetic_payload_size,
+          payload_size,
           queue,
           ack
          }).

--- a/src/tsung/ts_amqp.erl
+++ b/src/tsung/ts_amqp.erl
@@ -140,7 +140,7 @@ get_message(#amqp_request{type = 'basic.qos', prefetch_size = PrefetchSize,
     {Frame, NewAMQPSession};
 
 get_message(#amqp_request{type = 'basic.publish', exchange = Exchange,
-                          routing_key = RoutingKey, synthetic_payload_size = Size,
+                          routing_key = RoutingKey, payload_size = Size,
                           payload=Payload, persistent = Persistent},
             #state_rcv{session = AMQPSession}) ->
     Protocol = AMQPSession#amqp_session.protocol,

--- a/src/tsung_controller/ts_config_amqp.erl
+++ b/src/tsung_controller/ts_config_amqp.erl
@@ -111,14 +111,14 @@ parse_request(Element, Type = 'basic.publish', _Tab) ->
     RoutingKey = ts_config:getAttr(string, Element#xmlElement.attributes,
                                    routing_key, "/"),
     Size = ts_config:getAttr(float_or_integer, Element#xmlElement.attributes,
-                             synthetic_payload_size, 100),
+                             payload_size, 100),
     PersistentStr = ts_config:getAttr(string, Element#xmlElement.attributes,
                                       persistent, "false"),
     Payload = ts_config:getAttr(string, Element#xmlElement.attributes,
                                       payload, ""),
     Persistent = list_to_atom(PersistentStr),
     Request = #amqp_request{type = Type, exchange = Exchange,
-                            routing_key = RoutingKey, synthetic_payload_size = Size,
+                            routing_key = RoutingKey, payload_size = Size,
                             payload = Payload, persistent = Persistent},
     {no_ack, Request};
 parse_request(Element, Type = 'basic.consume', _Tab) ->

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -356,7 +356,7 @@ repeat | if | change_type | foreach | set_option | interaction )*>
     exchange CDATA ""
     routing_key CDATA ""
     payload CDATA ""
-    synthetic_payload_size CDATA "100"
+    payload_size CDATA "100"
     prefetch_size CDATA "0"
     prefetch_count CDATA "0"
     persistent CDATA "false"


### PR DESCRIPTION
Simple modifications to the existing AMQP implementation that will enable test scenarios for applications that consume AMQP messages.  The existing functionality (a synthetic payload used for testing the AMQP message server itself) has been retained.
