### PR TITLE
update amqp: add multiple channel, add waitForConfirms and waitForMessages

### DIFF
--- a/examples/amqp.xml.in
+++ b/examples/amqp.xml.in
@@ -32,26 +32,44 @@
                 <amqp type="connection.open" vhost="/"></amqp>
             </request>
 
+            <!--  open channel, channel id is from 1 to 10 -->
+            <for from="1" to="10" incr="1" var="loops">
+                <request>
+                    <amqp type="channel.open"></amqp>
+                </request>
+            </for>
+
             <!-- ignore this request if you don't need publisher confirm -->
-            <request>
-                <amqp type="confirm.select"></amqp>
-            </request>
+            <for from="1" to="10" incr="1" var="loops">
+                <request subst="true">
+                    <amqp type="confirm.select" channel="%%_loops%%"></amqp>
+                </request>
+            </for>
             
-            <for from="1" to="200" incr="1" var="loops">
-                <for from="1" to="10000" incr="1" var="counter">
+            <for from="1" to="10" incr="1" var="loops">
+                <for from="1" to="100" incr="1" var="counter">
                     <transaction name="publish">
                         <!-- specify payload_size to have tsung generate a payload for you -->
-                        <request>
-                            <amqp type="basic.publish" exchange="test_exchange" routing_key="4.queue_lb" persistent="true" payload_size="100"></amqp>
+                        <request subst="true">
+                            <amqp type="basic.publish" channel="%%_loops%%" exchange="test_exchange" routing_key="test_queue" persistent="true" payload_size="100"></amqp>
                         </request>
-                        <!-- substitutions are supported on the payload.  Payload will override payload_size. -->
-                        <request>
-                            <amqp type="basic.publish" exchange="test_exchange" routing_key="4.queue_lb" persistent="true" payload="Test Payload"></amqp>
+                        <!-- substitutions are supported on the payload. Payload will override payload_size. -->
+                        <request subst="true">
+                            <amqp type="basic.publish" channel="%%_loops%%" exchange="test_exchange" routing_key="test_queue" persistent="true" payload="Test Payload"></amqp>
                         </request>
                     </transaction>
                 </for>
-                <!--if publish with confirm, add a thinktime per 10000 msg(or other)-->
-                <thinktime value="1" />
+
+                <!-- if publish with confirm, add a waitForConfirms request as you need: timeout=1s -->
+                <request>
+                    <amqp type="waitForConfirms" timeout="1"></amqp>
+                </request>
+            </for>
+
+            <for from="1" to="10" incr="1" var="loops">
+                <request subst="true">
+                    <amqp type="channel.close" channel="%%_loops%%"></amqp>
+                </request>
             </for>
 
             <request>
@@ -63,17 +81,35 @@
                 <amqp type="connection.open"></amqp>
             </request>
 
+            <for from="1" to="10" incr="1" var="loops">
+                <request>
+                    <amqp type="channel.open"></amqp>
+                </request>
+            </for>
+
             <!-- ignore this request if you don't need qos(prefetch_count only) -->
+            <for from="1" to="10" incr="1" var="loops">
+                <request subst="true">
+                    <amqp type="basic.qos" channel="%%_loops%%" prefetch_count="200"></amqp>
+                </request>
+            </for>
+
+            <for from="1" to="10" incr="1" var="loops">
+                <request subst="true">
+                    <amqp type="basic.consume" channel="%%_loops%%" queue="test_queue" ack="true"></amqp>
+                </request>
+            </for>
+
+            <!-- wait to receive messages from the server: timeout=180s -->
             <request>
-                <amqp type="basic.qos" prefetch_count="200"></amqp>
+                <amqp type="waitForMessages" timeout="180"></amqp>
             </request>
 
-            <request>
-                <amqp type="basic.consume" queue="4.queue_lb" ack="false"></amqp>
-            </request>
-            
-            <!-- you need this thinktime to receive the message -->
-            <thinktime value="1800" /> 
+            <for from="1" to="10" incr="1" var="loops">
+                <request subst="true">
+                    <amqp type="channel.close" channel="%%_loops%%"></amqp>
+                </request>
+            </for>
 
             <request>
                 <amqp type="connection.close"></amqp>

--- a/include/ts_amqp.hrl
+++ b/include/ts_amqp.hrl
@@ -23,6 +23,7 @@
           password,
           heartbeat,
           vhost,
+          channel = "1",
           exchange,
           routing_key,
           confirm,
@@ -40,14 +41,20 @@
          }
        ).
 
+-record(ch, {
+          ack,
+          next_pub_seqno,
+          unconfirmed_set
+         }
+       ).
+
 -record(amqp_session, {
           vhost,
           protocol, 
-          channel,
-          next_pub_seqno,
-          unconfirmed_set,
-          ack,
+          channel_max = 65535,
+          map_num_pa,
           ack_buf,
-          status % status of handshake
+          status, % status of handshake
+          waiting = none % waiting state: {Channel, Expecting}
          }).
 

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -355,6 +355,7 @@ repeat | if | change_type | foreach | set_option | interaction )*>
 <!ATTLIST amqp 
     type CDATA #REQUIRED
     vhost CDATA "/"
+    channel CDATA "-1"
     exchange CDATA ""
     routing_key CDATA ""
     payload CDATA ""
@@ -363,6 +364,7 @@ repeat | if | change_type | foreach | set_option | interaction )*>
     prefetch_count CDATA "0"
     persistent CDATA "false"
     queue CDATA ""
+    timeout CDATA "1"
     ack CDATA "false" >
 
 <!ELEMENT modification (attr*) >


### PR DESCRIPTION
add following features:
1. client can do things(open channel, publish messages, consume messages, etc) on multiple channel;
2. add request type "waitForConfirms" for waiting confirms from sever when publishing messages;
3. and request type "waitForMessages" for waiting messages deliveries from server when consuming messages;
4. update amqp stat, add/update following stat:
   amqp_connected: counter for connection created;
   amqp_closed: counter for connection closed;
   amqp_channel_opened: counter for channel opened;
   amqp_channel_closed: counter for channel closed;
   amqp_consumer: counter for consumer(basic.consume)
   amqp_published: counter for messages published;
   amqp_confirmed: counter for messages confirmed;
   amqp_delivered: counter for message delivered to the client(and acked by the client);
