### PR TITLE
`tsung-recorder.sh` on Linux-x86_64 uses wrong path to Erlang

### DIFF
--- a/tsung-recorder.sh.in
+++ b/tsung-recorder.sh.in
@@ -7,7 +7,7 @@ case $UNAME in
         *) HOST=`hostname -s`;;
 esac
 
-INSTALL_DIR=@prefix@/lib/erlang/
+INSTALL_DIR=@EXPANDED_LIBDIR@/erlang/
 ERL=@ERL@
 MAIN_DIR=$HOME/.tsung
 LOG_DIR=$MAIN_DIR/log


### PR DESCRIPTION
Steal the fix from `tsung.sh`
