### PR TITLE
add text frame support for Websocket, and update doc

### DIFF
--- a/docs/conf-options.rst
+++ b/docs/conf-options.rst
@@ -103,7 +103,7 @@ you have to defined a range for available clients ports, for ex:
 
 .. index:: seed
 
-Setting the  seed for random numbers
+Setting the seed for random numbers
 ------------------------------------
 
 If you want to use a fixed seed for the random generator, you can use
@@ -116,16 +116,6 @@ different for every test).
   <option name="seed" value="42"/>
 
 
-Path for Websocket
-------------------
-
-When you use Websocket as a server type, you can set the connect path
-for Websocket as following:
-
-.. code-block:: xml
-
-  <option name="websocket_path" value="/chat"/>
-
 Path for BOSH
 ------------------
 
@@ -137,6 +127,25 @@ request:
   <option name="bosh_path" value="/http-bind"/>
 
 .. _jabber-options-label:
+
+
+Websocket options
+------------------
+
+When you use Websocket as a server type, you can set the following options
+for Websocket:
+
+.. code-block:: xml
+
+  <option name="websocket_path" value="/chat"/>
+
+  <!-- send websocket data with text frame, default binary-->
+  <option name="websocket_frame" value="text"/>
+
+Use ``websocket_path`` for setting the path of the websocket request; use
+``websocket_frame`` for setting the frame type(option type: binary and text,
+and binary as default) of the sending websocket data.
+
 
 XMPP/Jabber options
 -------------------

--- a/docs/conf-sessions.rst
+++ b/docs/conf-sessions.rst
@@ -792,7 +792,8 @@ Example with Websocket as a session type:
    </request>
    <request>
      <dyn_variable name="uid" jsonpath="uid"/>
-     <websocket type="message">{"user":"user", "password":"password"}</websocket>
+     <!-- send data with text frame, default binary-->
+     <websocket type="message" frame="text">{"user":"user", "password":"password"}</websocket>
    </request>
 
    <request subst="true">

--- a/include/ts_profile.hrl
+++ b/include/ts_profile.hrl
@@ -57,6 +57,7 @@
         {ssl_ciphers   = negociate, % for ssl only
          bosh_path = "/http-bind/",  % for bash only
          websocket_path = "/chat",  % for websocket only
+         websocket_frame = "binary",  % for websocket only
          retry_timeout = 10,        % retry sending in microsec
          idle_timeout  = 600000,    % timeout for local ack
          global_ack_timeout = infinity, % timeout for global ack

--- a/include/ts_websocket.hrl
+++ b/include/ts_websocket.hrl
@@ -30,6 +30,7 @@
           version = "13", % default is 13(rfc6455)
           type, % connect or message
           path, % connection path
+          frame = "binary",
           subprotos = [], % subprotocols
           data % websocket data
          }).

--- a/src/tsung/ts_websocket.erl
+++ b/src/tsung/ts_websocket.erl
@@ -85,10 +85,14 @@ get_message(#websocket_request{type = connect, path = Path,
                                                 SubProtocol, Version),
     {Request, WebsocketSession#websocket_session{status = waiting_handshake,
                                                  accept = Accept}};
-get_message(#websocket_request{type = message, data = Data},
+get_message(#websocket_request{type = message, data = Data, frame = Frame},
             #state_rcv{session = WebsocketSession})
   when WebsocketSession#websocket_session.status == connected ->
-    {websocket:encode_binary(list_to_binary(Data)), WebsocketSession};
+    ResultData = case Frame of
+        "text" -> websocket:encode_text(list_to_binary(Data));
+        _ -> websocket:encode_binary(list_to_binary(Data))
+    end,
+    {ResultData, WebsocketSession};
 get_message(#websocket_request{type = close},
             #state_rcv{session = WebsocketSession})
   when WebsocketSession#websocket_session.status == connected ->

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -832,6 +832,12 @@ parse(Element = #xmlElement{name=option, attributes=Attrs},
                     NewProto =  OldProto#proto_opts{websocket_path=Path},
                     lists:foldl( fun parse/2, Conf#config{proto_opts=NewProto},
                                  Element#xmlElement.content);
+                "websocket_frame" ->
+                    Frame = getAttr(string,Attrs, value, ?config(websocket_frame)),
+                    OldProto =  Conf#config.proto_opts,
+                    NewProto =  OldProto#proto_opts{websocket_frame=Frame},
+                    lists:foldl( fun parse/2, Conf#config{proto_opts=NewProto},
+                                 Element#xmlElement.content);
                 "bosh_path" ->
                     Path = getAttr(string,Attrs, value, ?config(bosh_path)),
                     OldProto =  Conf#config.proto_opts,

--- a/src/tsung_controller/ts_config_websocket.erl
+++ b/src/tsung_controller/ts_config_websocket.erl
@@ -51,10 +51,13 @@ parse_config(Element = #xmlElement{name = websocket},
     Type = ts_config:getAttr(atom, Element#xmlElement.attributes, type),
     ValRaw = ts_config:getText(Element#xmlElement.content),
     Path = ts_config:getAttr(string, Element#xmlElement.attributes, path, "/"),
+    Frame = ts_config:getAttr(string, Element#xmlElement.attributes, frame,
+                              "binary"),
 
     %%is this needed ?
     CleanStr = ts_utils:clean_str(ValRaw),
-    Request = #websocket_request{data=CleanStr, type=Type, path=Path},
+    Request = #websocket_request{data = CleanStr, type = Type,
+                                 path = Path, frame = Frame},
 
     Ack = case Type of
               message ->

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -355,6 +355,7 @@ repeat | if | change_type | foreach | set_option | interaction )*>
 <!ATTLIST websocket
     type (connect | message | close) #REQUIRED
     ack  (no_ack | parse) #IMPLIED
+    frame (binary | text) #IMPLIED
     path CDATA "/" >
 
 <!ELEMENT amqp (#PCDATA) >


### PR DESCRIPTION
add text frame support for websocket, for server type, it can be set by option: 

``` xml
<option name="websocket_frame" value="text"/>
```

for session type, it can be set by attribute "frame":

``` xml
<websocket type="message" frame="text">{"user":"user", "password":"password"}</websocket>
```
