### PR TITLE
Allows an http DELETE request to have a body cause RFC2616 (HTTP 1.1) is...

### DIFF
--- a/src/tsung/ts_http.erl
+++ b/src/tsung/ts_http.erl
@@ -128,7 +128,7 @@ get_message2(Req=#http_request{method=head}) ->
     ts_http_common:http_no_body(?HEAD, Req);
 
 get_message2(Req=#http_request{method=delete}) ->
-    ts_http_common:http_no_body(?DELETE, Req);
+    ts_http_common:http_body(?DELETE, Req);
 
 get_message2(Req=#http_request{method=post}) ->
     ts_http_common:http_body(?POST, Req);


### PR DESCRIPTION
... not explicitly forbidding it.

Ref: http://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request
