### PR TITLE
Allow setting of dynamic vars for MQTT's username and password:

### DIFF
--- a/src/tsung/ts_mqtt.erl
+++ b/src/tsung/ts_mqtt.erl
@@ -261,6 +261,22 @@ parse_config(Element, Conf) ->
 %% Returns: #websocket_request
 %%----------------------------------------------------------------------
 add_dynparams(true, {DynVars, _S},
+              Param = #mqtt_request{type = connect, clean_start = CleanStart,
+				    keepalive = KeepAlive, will_topic = WillTopic,
+				    will_qos = WillQos, will_msg = WillMsg,
+				    will_retain = WillRetain, username = UserName,
+				    password = Password},
+              _HostData) ->
+    NewUserName = ts_search:subst(UserName, DynVars),
+    NewPassword = ts_search:subst(Password, DynVars),
+    Param#mqtt_request{ type = connect,
+			clean_start = CleanStart,
+			keepalive = KeepAlive, will_topic = WillTopic,
+			will_qos = WillQos, will_msg = WillMsg,
+			will_retain = WillRetain,
+			username = NewUserName,
+			password = NewPassword };
+add_dynparams(true, {DynVars, _S},
               Param = #mqtt_request{type = publish, topic = Topic,
                                     payload = Payload},
               _HostData) ->


### PR DESCRIPTION
- This allows pulling out the values of the username and password if set as dynamic vars.
- Essential to load an external file with usernames and password.
