### PR TITLE
[#TSUN-299] Move ssl:start() from ts_jabber to main tsung

### DIFF
--- a/src/tsung/ts_jabber.erl
+++ b/src/tsung/ts_jabber.erl
@@ -181,7 +181,6 @@ presence_bidi(RcvdXml, State)->
     bidi_resp(subscribed,RcvdXml,SubMatches,State).
 
 starttls_bidi(_RcvdXml, #state_rcv{socket= Socket}=State)->
-    ssl:start(),
     Req = subst(State#state_rcv.request#ts_request.param, State#state_rcv.dynvars),
     Opt = lists:filter(fun({_,V}) -> V /= undefined end, 
                       [{certfile,Req#jabber.certfile},

--- a/src/tsung/tsung.erl
+++ b/src/tsung/tsung.erl
@@ -43,6 +43,7 @@ start() ->
 %%----------------------------------------------------------------------
 start(_Type, _StartArgs) ->
 % error_logger:tty(false),
+    ssl:start(),
     ?LOG("open logfile  ~n",?DEB),
     LogFileEnc = ts_config_server:decode_filename(?config(log_file)),
     LogFile = filename:join(LogFileEnc, atom_to_list(node()) ++ ".log"),


### PR DESCRIPTION
This is a naïve attempt to patch the "Error: ssl_not_started" problem I reported in [TSUN-299](https://support.process-one.net/browse/TSUN-299). So far it seems to be working for me.
