### PR TITLE
[MQTT] Last Will and Testament should not be included if will_topic is not set.

### DIFF
--- a/src/lib/mqtt_frame.erl
+++ b/src/lib/mqtt_frame.erl
@@ -253,7 +253,9 @@ encode_message(#mqtt{type = ?CONNECT, arg = Options}) ->
   end,
   {WillFlag, WillQoS, WillRetain, PayloadList} =
         case Options#connect_options.will of
-            #will{ topic = undefined, message = undefined } ->
+            #will{ topic = undefined } ->
+                {0, 0, 0, [encode_string(Options#connect_options.client_id)]};
+            #will{ topic = "" } ->
                 {0, 0, 0, [encode_string(Options#connect_options.client_id)]};
             undefined ->
                 {0, 0, 0, [encode_string(Options#connect_options.client_id)]};


### PR DESCRIPTION
Currently it is sending a last will and testament with a blank topic and a blank message, but if will_topic is omitted it should not include the will in the connect packet.
