### PR TITLE
Add two config option

### DIFF
--- a/include/ts_profile.hrl
+++ b/include/ts_profile.hrl
@@ -56,6 +56,7 @@
 -record(proto_opts,
         {ssl_ciphers   = negociate, % for ssl only
          bosh_path = "/http-bind/",  % for bash only
+         tcp_reuseaddr = false,  % for tcp reuseaddr
          websocket_path = "/chat",  % for websocket only
          websocket_frame = "binary",  % for websocket only
          retry_timeout = 10,        % retry sending in microsec

--- a/src/tsung/ts_tcp.erl
+++ b/src/tsung/ts_tcp.erl
@@ -32,9 +32,11 @@
 -include("ts_profile.hrl").
 -include("ts_config.hrl").
 
-protocol_options(#proto_opts{tcp_rcv_size=Rcv, tcp_snd_size=Snd}) ->
+protocol_options(#proto_opts{tcp_rcv_size = Rcv, tcp_snd_size = Snd,
+                             tcp_reuseaddr = Reuseaddr}) ->
     [binary,
      {active, once},
+     {reuseaddr, Reuseaddr},
      {recbuf, Rcv},
      {sndbuf, Snd},
      {keepalive, true} %% FIXME: should be an option

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -888,6 +888,10 @@ parse(Element = #xmlElement{name=option, attributes=Attrs},
                         false ->
                             lists:foldl( fun parse/2, Conf, Element#xmlElement.content)
                     end;
+                "global_ack_number" ->
+                    GlobalAckNumber = getAttr(integer, Attrs, value, ?config(global_ack_number)),
+                    ts_timer:config(GlobalAckNumber),
+                    lists:foldl( fun parse/2, Conf#config{}, Element#xmlElement.content);
                 Other ->
                     ?LOGF("Unknown option ~p !~n",[Other], ?WARN),
                     lists:foldl( fun parse/2, Conf, Element#xmlElement.content)

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -877,6 +877,17 @@ parse(Element = #xmlElement{name=option, attributes=Attrs},
                     lists:foldl( fun parse/2,
                                  Conf#config{file_server=[{Id, FileName} | Conf#config.file_server]},
                                  Element#xmlElement.content);
+                "tcp_reuseaddr" ->
+                    Reuseaddr = getAttr(atom, Attrs, value, false),
+                    case Reuseaddr of
+                        true ->
+                            OldProto =  Conf#config.proto_opts,
+                            NewProto =  OldProto#proto_opts{tcp_reuseaddr = Reuseaddr},
+                            lists:foldl( fun parse/2, Conf#config{proto_opts=NewProto},
+                                         Element#xmlElement.content);
+                        false ->
+                            lists:foldl( fun parse/2, Conf, Element#xmlElement.content)
+                    end;
                 Other ->
                     ?LOGF("Unknown option ~p !~n",[Other], ?WARN),
                     lists:foldl( fun parse/2, Conf, Element#xmlElement.content)


### PR DESCRIPTION
1. tcp_reuseaddr as discussed at https://github.com/processone/tsung/pull/90
2. global_ack_number, currently global ack number can only be used with jabber (jabber_global_number option), but other session type may need this feature too.