### PR TITLE
handle ssl_closed in ts_client

### DIFF
--- a/src/tsung/ts_client.erl
+++ b/src/tsung/ts_client.erl
@@ -363,7 +363,7 @@ handle_info2({tcp_closed, Socket, _Data}, StateName, State ) ->
                 end, Acc end, unused, DictList),
     {next_state, StateName, State};
 
-handle_info2({ssl_closed, Socket, _Data}, StateName, State) ->
+handle_info2({ssl_closed, Socket}, StateName, State) ->
     ?LOGF("ssl_closed received in state ~p~n", [StateName], ?NOTICE),
 
     % set old socket to none, like when receiving tcp_closed


### PR DESCRIPTION
While running a load test which overloaded the load balancer (which also happens to do the SSL/TLS termination) I got **many hundred thousands** of the following log entries across all generators. **This induced quite a stress on the controller node, in my opinion for no good reason.**

This pull request aims to avoid the extensive logging of those events:

```
=INFO REPORT==== 7-Aug-2014::11:54:47 ===
           ts_client:(4:<0.31230.0>) connection close while sending message !

=INFO REPORT==== 7-Aug-2014::11:54:47 ===
           ts_client:(3:<0.31230.0>) Error: Unknown msg {ssl_closed,
                                                         {sslsocket,
                                                          {gen_tcp,
                                                           #Port<0.18586>,
                                                           tls_connection},
                                                          <0.31231.0>}} receive in state think, stop
```

When I understand correctly, `ts_client` gets notified about the `tcp_closed` and `ssl_closed` (see [ssl](http://www.erlang.org/doc/man/ssl.html)) events separately, but only handles `tcp_closed`. This results in the client/user process termination, although the error could have been recovered (given there are retries left).

I also lowered the log level for `connection close while sending message` messages and added `ts_mon:add({ count, error_connection_closed })` instead. For my understanding, losing a TCP connection is not worth a warning, but a rather normal effect of load tests.
