### PR TITLE
add missing case clauses

### DIFF
--- a/src/tsung/ts_client.erl
+++ b/src/tsung/ts_client.erl
@@ -863,7 +863,11 @@ handle_next_request(Request, State) ->
         {error, Reason} ->
             case Reason of
                 timeout ->
-                    ts_mon:add({count, error_connect_timeout})
+                    ts_mon:add({count, error_connect_timeout});
+                closed ->
+                    ts_mon:add({count, error_connect_closed});
+                _ ->
+                    ok
             end,
             ts_mon:add({ count, error_abort_max_conn_retries }),
             {stop, normal, State}


### PR DESCRIPTION
While testing/debugging https://github.com/processone/tsung/pull/100 I just noticed that, 9c2aa861b4d0fdca4f248738d92fb080e40b0426 is missing some case clauses: https://github.com/processone/tsung/blame/master/src/tsung/ts_client.erl#L864-L867
