### PR TITLE
Prevent tsplot to require a X Server

### DIFF
--- a/src/tsung-plotter/tsplot.py.in
+++ b/src/tsung-plotter/tsplot.py.in
@@ -42,6 +42,11 @@ sys.path.append(LIBDIR)
 
 from tsung_plotter.tsung import TsungLog
 from ConfigParser import ConfigParser
+
+# Prevents pylab from requiring a X Server to run
+import matplotlib
+matplotlib.use("Agg")
+
 from pylab import *
 
 


### PR DESCRIPTION
According to [this answer on StackOverflow](http://stackoverflow.com/questions/4931376/generating-matplotlib-graphs-without-a-running-x-server) doing this `import` and `use` statement will prevent pylab from requiring a running X Server. 

I tested it briefly on a ubuntu virtualbox and it seems to work.
