### PR TITLE
Fix crash when use_controller_vm="false" and controller id is not empty

### DIFF
--- a/src/tsung/ts_utils.erl
+++ b/src/tsung/ts_utils.erl
@@ -173,7 +173,9 @@ init_seed({A,B,C}) ->
 get_node_id() ->
     case string:tokens(atom_to_list(node()),"@") of
         ["tsung_control"++_,_]    -> 123456;
-        ["tsung"++I,_]            -> list_to_integer(I);
+        ["tsung"++Tail,_]         ->
+            {match, [I]} = re:run(Tail, "\\d+$", [{capture, all, list}]),
+            list_to_integer(I);
         _                         -> 654321
     end.
 


### PR DESCRIPTION
```
$ tsung -i test1 -f test.xml start
```

```
tsung:(3:<0.53.0>) Can't start supervisor ! {error,
                                             {shutdown,
                                              {failed_to_start_child,
                                               ts_local_mon,
                                               {badarg,
                                                [{erlang,
                                                  list_to_integer,
                                                  ["_test1_0"],
                                                  []},
                                                 {ts_utils,
                                                  get_node_id,
                                                  0,
                                                  [{file,
                                                    "src/tsung/ts_utils.erl"},
                                                   {line,176}]},
                                                 {ts_local_mon,
                                                  init,1,
                                                  [{file,
                                                    "src/tsung/ts_local_mon.erl"},
                                                   {line,87}]},
                                                 {gen_server,
                                                  init_it,6,
                                                  [{file,
                                                    "gen_server.erl"},
                                                   {line,306}]},
                                                 {proc_lib,
                                                  init_p_do_apply,
                                                  3,
                                                  [{file,
                                                    "proc_lib.erl"},
                                                   {line,
                                                    237}]}]}}}}
```
