### PR TITLE
Fix race condition in ts_utils:make_dir/1

### DIFF
--- a/src/tsung/ts_local_mon.erl
+++ b/src/tsung/ts_local_mon.erl
@@ -88,7 +88,7 @@ init([]) ->
     LogFileEnc = ts_config_server:decode_filename(?config(log_file)),
     FileName = filename:join(LogFileEnc, "tsung-"++Id ++ ".dump"),
     LogDir = filename:dirname(FileName),
-    ts_utils:make_dir_raw(LogDir),
+    ok = ts_utils:make_dir_raw(LogDir),
     case file:open(FileName,[write,raw, delayed_write]) of
         {ok, IODev} ->
             {ok, #state{dump_iodev=IODev}};

--- a/src/tsung/ts_utils.erl
+++ b/src/tsung/ts_utils.erl
@@ -447,6 +447,8 @@ make_dir_rec(Path, FileMod,[Parent|Childs]) ->
             case FileMod:make_dir(CurrentDir) of
                 ok ->
                     make_dir_rec(CurrentDir, FileMod, Childs);
+                {error, eexist} ->
+                    make_dir_rec(CurrentDir, FileMod, Childs);
                 Error ->
                     Error
             end;


### PR DESCRIPTION
There is a race condition, when multiple Erlang VMs are started almost simultaneously which is a typical case if you are not using tsung's SMP option.

I observed it a couple of times now, that `ts_local_mon` failed to write the `protocol_local` dumpfile. The reason is that the check and set is not one atomic operation in `ts_utils:make_dir_rec/3`. There is a window after the check, when another process could have created the directory already, resulting in a `{error, eexist}`.

In https://github.com/processone/tsung/pull/88 the check for `ok` in `ts_local_mon:init/1` was wrongfully removed (I'm sorry for that). Back then I noticed the `{error, eexist}` and assumed that this is a result from the fact that the **entire** log directory already existed, which is not the case. `ts_utils:make_dir/1` and `ts_utils:make_dir_raw/1` should now be better protected against the mentioned race condition.