### PR TITLE
Remove non-existing modules from .app file

### DIFF
--- a/src/tsung/tsung.app.in
+++ b/src/tsung/tsung.app.in
@@ -6,12 +6,10 @@
                        ts_launcher,
                        ts_session_cache,
                        ts_client,
-                       ts_client_rcv,
                        ts_client_sup,
                        ts_sup,
                        ts_stats,
-                       ts_utils,
-                       ts_profile
+                       ts_utils
                       ]},
        {registered,   [
                        ts_launcher,


### PR DESCRIPTION
I am mostly opening this PR to trigger a discussion on the Tsung .app file. The patch fixes an immediate issue but leaves open a larger problem.

Currently this file has invalid modules in it (probably were removed long ago) and is clearly missing many other modules. It doesn't look like this module list is maintained.

This causes no problem when using Tsung as per the manual (by installing or running the generated shell script) but becomes problematic if one wants to use Tsung as a dependency (from the erlang.mk package index for example) or to embed Tsung inside a release.

I would fix the .app file but considering its current state I think it would end up being unmaintained. Perhaps there is a way to fill in modules automatically through the configure script? I am not very knowledgeable with autotools but that would be fantastic if it were possible.