### PR TITLE
Work around compiler warning and provide backward compatibility.

### DIFF
--- a/src/lib/oauth_hmac_sha1.erl
+++ b/src/lib/oauth_hmac_sha1.erl
@@ -1,4 +1,5 @@
 %% Copyright (c) 2008-2009 Tim Fletcher <http://tfletcher.com/>
+%% Copyright (c) 2015      Christoher Meng <http://cicku.me/>
 %% 
 %% Permission is hereby granted, free of charge, to any person
 %% obtaining a copy of this software and associated documentation
@@ -28,7 +29,15 @@
 -spec signature(string(), string(), string()) -> string().
 signature(BaseString, CS, TS) ->
   Key = oauth_uri:calate("&", [CS, TS]),
-  base64:encode_to_string(crypto:sha_mac(Key, BaseString)).
+  base64:encode_to_string(sha2hmac(Key, BaseString)).
+
+sha2hmac(Key, Data) ->
+  case erlang:function_exported(crypto, hmac, 3) of
+    true ->
+      crypto:hmac(sha, Key, Data);
+    false ->
+      crypto:sha_mac(Key, Data)
+  end.
 
 -spec verify(string(), string(), string(), string()) -> boolean().
 verify(Signature, BaseString, CS, TS) ->


### PR DESCRIPTION
While compiling this using erlc, warning thrown:

`Warning: crypto:sha_mac/2 is deprecated and will be removed in in a future release; use crypto:hmac/3`

In order to support older OTP releases it's better to have crypto:sha_mac there but for new OTPs we should use crypto:hmac instead.