### PR TITLE
Add initial presence to pubsub subscriber example

### DIFF
--- a/examples/jabber_node.xml.in
+++ b/examples/jabber_node.xml.in
@@ -71,6 +71,7 @@
      <request> <jabber type="auth_sasl_bind" ack="local" ></jabber></request>
      <thinktime value="2" random="true"/>
      <request> <jabber type="auth_sasl_session" ack="local" ></jabber></request>
+     <request> <jabber type="presence:initial" ack="no_ack"/> </request>
      <thinktime value="5" random="true"/>
 
      <request>


### PR DESCRIPTION
If presence is not sent, ejabberd will not route pubsub event `messages`.