### PR TITLE
Fix add option to specify SSL protocol

### DIFF
--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -788,9 +788,9 @@ parse(Element = #xmlElement{name=option, attributes=Attrs},
                     lists:foldl( fun parse/2, Conf#config{proto_opts=NewProto},
                                  Element#xmlElement.content);
                 "ssl_versions" ->
-                    Protocol = getAttr(string,Attrs, value, negotiate),
+                    Protocol = getAttr(atom,Attrs, value, negotiate),
                     OldProto =  Conf#config.proto_opts,
-                    NewProto =  OldProto#proto_opts{ssl_versions=Protocol},
+                    NewProto =  OldProto#proto_opts{ssl_versions=[Protocol]},
                     lists:foldl( fun parse/2, Conf#config{proto_opts=NewProto},
                                  Element#xmlElement.content);
                 "ssl_reuse_sessions" ->


### PR DESCRIPTION
Forgot to set Protocol as a list in https://github.com/processone/tsung/pull/151. We need to pass a list to ssl_version. 