### PR TITLE
fix web gui on mac

### DIFF
--- a/src/tsung_controller/ts_controller_sup.erl
+++ b/src/tsung_controller/ts_controller_sup.erl
@@ -105,7 +105,7 @@ init([LogDir]) ->
 
 start_inets(LogDir,Redirect) ->
     inets:start(),
-    Path = filename:join(filename:dirname(code:which(tsung_controller)),"../../../../share/tsung/templates/style"),
+    Path = filename:join(filename:dirname(code:which(tsung_controller)),"../templates/style"),
     {ok,Styles} = file:list_dir(Path),
     DestDir = filename:join(LogDir,"style"),
     file:make_dir(DestDir),


### PR DESCRIPTION
Hi,I compiled tsung on mac.when I run tsung -f http_simple.xml start. Here is the log 
```
Starting Tsung
Log directory is: /Users/zhongweilzw/.tsung/log/20160701-1955
Can't start ! {error,
                  {{badmatch,{error,enoent}},
                   [{ts_controller_sup,start_inets,1,
                        [{file,"src/tsung_controller/ts_controller_sup.erl"},
                         {line,105}]},
                    {ts_controller_sup,init,1,
                        [{file,"src/tsung_controller/ts_controller_sup.erl"},
                         {line,91}]},
                    {supervisor,init,1,[{file,"supervisor.erl"},{line,287}]},
                    {gen_server,init_it,6,
                        [{file,"gen_server.erl"},{line,328}]},
                    {proc_lib,init_p_do_apply,3,
                        [{file,"proc_lib.erl"},{line,240}]}]}}
```
And if I use the flag ` -n `.It works. Finally I found the problem and create the pull request☕️. 