### PR TITLE
define xmlns for muc_join - fixes joining rooms on Cisco Jabber

### DIFF
--- a/src/tsung/ts_jabber_common.erl
+++ b/src/tsung/ts_jabber_common.erl
@@ -695,6 +695,7 @@ publish_pubsub_node(Domain, PubSubComponent, Username, Node, Size, Stamped) ->
 
 muc_join(Room,Nick, Service) ->
     Result = list_to_binary(["<presence to='", Room,"@", Service,"/", Nick, "'>",
+                             "<x xmlns='http://jabber.org/protocol/muc'/>",
                              " </presence>"]),
     Result.
 


### PR DESCRIPTION
When using Tsung to benchmark Cisco Jabber,
I would get a 401 not authorized when using muc:join,
`Send:1468999188.680235:<0.129.0>:<presence to='testroom@foo.bar/john.doe'> </presence>
Recv:1468999188.683205:<0.129.0>:<presence from='testroom@foo.bar' to='john.doe@foo.bar/tsung' type='error'><error code='401' type='auth'><not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/></error><x xmlns='http://jabber.org/protocol/muc'/></presence>
`
Figured I need to send the xmlns, which then works fine (i.e the process is able to join the muc room)