### PR TITLE
Record extra headers in the HTTP proxy recorder

### DIFF
--- a/src/tsung_recorder/ts_proxy_http.erl
+++ b/src/tsung_recorder/ts_proxy_http.erl
@@ -328,6 +328,24 @@ record_request(State=#state_rec{prev_host=Host, prev_port=Port, prev_scheme=Sche
                   "~n  <soap action='~s'></soap>~n",
                   fun(A) -> string:strip(A,both,$") end ), %"
 
+    %% Content auto-negotiation headers
+    record_header(Fd,ParsedHeader,"accept",
+                  "~n  <http_header name='Accept' value='~s' />"),
+    record_header(Fd,ParsedHeader,"accept-encoding",
+                  "~n  <http_header name='Accept-Encoding' value='~s' />"),
+    record_header(Fd,ParsedHeader,"accept-charset",
+                  "~n  <http_header name='Accept-Charset' value='~s' />"),
+    record_header(Fd,ParsedHeader,"accept-language",
+                  "~n  <http_header name='Accept-Language' value='~s' />"),
+    record_header(Fd,ParsedHeader,"x-requested-with",
+                  "~n  <http_header name='X-Requested-With' value='~s' />"),
+
+    %% Caching headers
+    record_header(Fd,ParsedHeader,"cache-control",
+                  "~n  <http_header name='Cache-Control' value='~s' />"),
+    record_header(Fd,ParsedHeader,"pragma",
+                  "~n  <http_header name='Pragma' value='~s' />"),
+
     io:format(Fd,"</http></request>~n",[]),
     {ok,State#state_rec{prev_port=NewPort,ext_file_id=NewId,prev_host=NewHost,prev_scheme=NewScheme}}.
 


### PR DESCRIPTION
Many web apps change the response based on the Accept: header in order to support both AJAX and traditional HTML endpoints on the same URLs (and in the past it was common also to look for XMLHttpRequest in the x-requested-with header, though that is used less and less these days).  And the Cache-Control: and Pragma: headers often affect whether requests go through to the app tier.