### PR TITLE
 fixing oauth 1.0  authorization header creation, signature with body, alphanumerical nonce

### DIFF
--- a/include/ts_http.hrl
+++ b/include/ts_http.hrl
@@ -104,6 +104,7 @@
 -define(DELETE, "DELETE").
 -define(OPTIONS, "OPTIONS").
 -define(PATCH, "PATCH").
+-define(BODY_PARAM, "application/x-www-form-urlencoded").
 
 -define(USER_AGENT, "Tsung").
 -define(USER_AGENT_ERROR_MSG, "Total sum of user agents frequency is not equal to 100").

--- a/src/tsung/ts_http_common.erl
+++ b/src/tsung/ts_http_common.erl
@@ -186,11 +186,22 @@ oauth_sign(Method, #http_request{url=URL,
                          oauth_consumer=Consumer,
                          oauth_access_token=AccessToken,
                          oauth_access_secret=AccessSecret,
-                         oauth_url=ServerURL})->
+                         oauth_url=ServerURL,
+                         content_type = ContentType,
+                         body = Body})->
     %%UrlParams = oauth_uri:params_from_string(URL),
     [_He|Ta] = string:tokens(URL,"?"),
     UrlParams = oauth_uri:params_from_string(lists:flatten(Ta)),
-    Params = oauth:signed_params(Method, ServerURL, UrlParams, Consumer, AccessToken, AccessSecret),
+	
+    if
+      ContentType =:= ?BODY_PARAM ->
+        BodyParams = oauth_uri:params_from_string(lists:flatten(binary_to_list(Body))),
+        AllParams = UrlParams ++ BodyParams;
+      true ->
+        AllParams = UrlParams
+    end,
+	
+    Params = oauth:signed_params(Method, ServerURL, AllParams, Consumer, AccessToken, AccessSecret),
     ["Authorization: OAuth ", oauth_uri:params_to_header_string(Params),?CRLF].
 
 %%----------------------------------------------------------------------


### PR DESCRIPTION
 fixing oauth 1.0:
- authorization header creation
- fixing signature calculation with POST body params
- nonce should be alphanumerical
