### PR TITLE
Allow path to HTML templates to be specified from absolute pathname.

### DIFF
--- a/src/tsung_controller/ts_controller_sup.erl
+++ b/src/tsung_controller/ts_controller_sup.erl
@@ -105,7 +105,7 @@ init([LogDir]) ->
 
 start_inets(LogDir,Redirect) ->
     inets:start(),
-    Path = filename:join(filename:dirname(code:which(tsung_controller)),"../../../../share/tsung/templates/style"),
+    Path = filename:join(template_path(), "style"),
     {ok,Styles} = file:list_dir(Path),
     DestDir = filename:join(LogDir,"style"),
     file:make_dir(DestDir),
@@ -139,4 +139,11 @@ start_inets(LogDir,Redirect) ->
             ?LOG("Starting inets on port 8091",?INFO);
         Error ->
             ?LOGF("Error while starting inets on port 8091: ~p",[Error],?ERR)
+    end.
+
+template_path() ->
+    case ?config(template_path) of
+        beam_relative ->
+            filename:join(filename:dirname(code:which(tsung_controller)),"../../../../share/tsung/templates");
+        Other -> Other
     end.

--- a/src/tsung_controller/tsung_controller.app.in
+++ b/src/tsung_controller/tsung_controller.app.in
@@ -88,7 +88,8 @@
                      {config_file, "./tsung.xml"},
                      {log_file, "./tsung.log"},
                      {match_log_file, "./match.log"},
-                     {exclude_tag, ""}
+                     {exclude_tag, ""},
+                     {template_path, beam_relative}
                     ]},
        {applications, [ @ERLANG_APPLICATIONS@ ]},
        {start_phases, [{load_config, []},{start_os_monitoring,[{timeout,30000}]},


### PR DESCRIPTION
If you set the "template_path" environment variable for the
ts_controller app, tsung will use that path instead of computing it
from the location of the controller beam file.

The original behavior is preserved by using the 'beam_relative' atom
as the value of template_path, which is the default in
ts_controller.app.
