### PR TITLE
Fix some dialyzer errors when using erl_scan:string().

### DIFF
--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -454,7 +454,7 @@ parse(Element = #xmlElement{name=transaction, attributes=Attrs},
       Conf = #config{session_tab = Tab, sessions=[CurS|_], curid=Id}) ->
 
     RawName = getAttr(Attrs, name),
-    {ok, [{atom,1,Name}],1} = erl_scan:string("tr_"++RawName),
+    {ok, [{atom,_,Name}],_} = erl_scan:string("tr_"++RawName),
     ?LOGF("Add start transaction ~p in session ~p as id ~p",
          [Name,CurS#session.id,Id+1],?INFO),
     ets:insert(Tab, {{CurS#session.id, Id+1}, {transaction,start,Name}}),
@@ -605,7 +605,7 @@ parse(_Element = #xmlElement{name=repeat,attributes=Attrs,content=Content},
 parse(#xmlElement{name=dyn_variable, attributes=Attrs},
       Conf=#config{sessions=[CurS|_],dynvar=DynVars}) ->
     StrName  = ts_utils:clean_str(getAttr(Attrs, name)),
-    {ok, [{atom,1,Name}],1} = erl_scan:string("'"++StrName++"'"),
+    {ok, [{atom,_,Name}],_} = erl_scan:string("'"++StrName++"'"),
     {Type,Expr} = case {getAttr(string,Attrs,re,none),
                         getAttr(string,Attrs,pgsql_expr,none),
                         getAttr(string,Attrs,xpath,none),
@@ -677,7 +677,7 @@ parse( #xmlElement{name=interaction, attributes=Attrs},
 
     Action   = list_to_atom(getAttr(string, Attrs, action, "send")),
     RawId = getAttr(Attrs, id),
-    {ok, [{atom,1,IdInteraction}],1} = erl_scan:string("tr_"++RawId),
+    {ok, [{atom,_,IdInteraction}],_} = erl_scan:string("tr_"++RawId),
 
     ets:insert(Tab,{{CurS#session.id, Id+1}, {interaction, Action, IdInteraction}}),
     ?LOGF("Parse  interaction  ~p:~p ~n",[Action,Id],?NOTICE),
@@ -1104,16 +1104,16 @@ getTypeAttr(string, String)-> String;
 getTypeAttr(list, String)-> String;
 getTypeAttr(float_or_integer, String)->
     case erl_scan:string(String) of
-        {ok, [{integer,1,I}],1} -> I;
-        {ok, [{float,1,F}],1} -> F
+        {ok, [{integer,_,I}],_} -> I;
+        {ok, [{float,_,F}],_} -> F
     end;
 getTypeAttr(integer_or_string, String)->
     case erl_scan:string(String) of
-        {ok, [{integer,1,I}],1} -> I;
+        {ok, [{integer,_,I}],_} -> I;
         _ -> String
     end;
 getTypeAttr(Type, String) ->
-    {ok, [{Type,1,Val}],1} = erl_scan:string(String),
+    {ok, [{Type,_,Val}],_} = erl_scan:string(String),
     Val.
 
 


### PR DESCRIPTION
The matching against types in erl_anno caused dialyzer to spit out
some ugly warnings. These match values were unused, so instead just
match on what's required.
