### PR TITLE
Add test and build artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,26 @@ configure
 install-sh
 stamp-*
 
+# make test artifacts
+ebin-test/
+cover_report/
+
+TEST-ts_test_all.xml
+badpop.xml
+http_distributed.xml
+http_simple.xml
+jabber.xml
+jabber_muc.xml
+pgsql.xml
+src/test/badpop.xml
+src/test/thinkfirst.xml
+src/test/usersdb.csv
+src/test/xmpp-muc.xml
+test_case.xml
+thinkfirst.xml
+xmpp-muc.xml
+
+
 # build artifacts
 Makefile
 config.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,19 @@ aclocal.m4
 configure
 install-sh
 stamp-*
+
+# build artifacts
+Makefile
+config.log
+config.status
+src/log2tsung.pl
+src/tsung-plotter/tsplot.py
+src/tsung-rrd.pl
+src/tsung/tsung.app
+src/tsung_controller/tsung_controller.app
+src/tsung_percentile.pl
+src/tsung_recorder/tsung_recorder.app
+src/tsung_stats.pl
+tsung-recorder.sh
+tsung.sh
+tsung.spec


### PR DESCRIPTION
I started with a fresh clone of this repository and noticed that there are some blindspots in `gitignore`. I checked out the repository fresh, and did the configure + make test + make install run and added artifacts to `.gitignore`.

Maybe we can move some of the generated artifacts into a `test` or `tmp` subdirectory, so that we don't need to manually exclude them.