### PR TITLE
Add SASL EXTERNAL support for Jabber

### DIFF
--- a/src/tsung/ts_jabber_common.erl
+++ b/src/tsung/ts_jabber_common.erl
@@ -297,6 +297,8 @@ get_message2(Jabber=#jabber{type = 'auth_sasl'}) ->
     auth_sasl(Jabber,"PLAIN");
 get_message2(Jabber=#jabber{type = 'auth_sasl_anonymous'}) ->
     auth_sasl(Jabber,"ANONYMOUS");
+get_message2(Jabber=#jabber{type = 'auth_sasl_external'}) ->
+    auth_sasl(Jabber,"EXTERNAL");
 get_message2(Jabber=#jabber{type = 'auth_sasl_bind'}) ->
     auth_sasl_bind(Jabber);
 get_message2(Jabber=#jabber{type = 'auth_sasl_session'}) ->
@@ -424,6 +426,8 @@ auth_set_sip(Username, Passwd, Domain, Type, Nonce, Realm,Resource) ->
 %%----------------------------------------------------------------------
 auth_sasl(_,"ANONYMOUS")->
     list_to_binary(["<auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='ANONYMOUS'/>"]);
+auth_sasl(_,"EXTERNAL")->
+    list_to_binary(["<auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='EXTERNAL'>=</auth>"]);
 auth_sasl(#jabber{username=Name,passwd=Passwd},Mechanism)->
         auth_sasl(Name, Passwd, Mechanism).
 


### PR DESCRIPTION
This change adds the ability to authenticate using the SASL EXTERNAL mechanism. Used with starttls to load test users connecting with client certificates.

An example of a configuration file using SASL EXTERNAL can be found here[0]

[0] - https://gist.github.com/victorqhong/31f23db58716142797f00926d534deb2