### PR TITLE
add origin for websocket requests, if not set it defaults to host

### DIFF
--- a/docs/conf-sessions.rst
+++ b/docs/conf-sessions.rst
@@ -878,7 +878,16 @@ If you use ``change_type`` to start a websocket, don't forget to set
 
 .. code-block:: xml
 
- <change_type new_type="ts_websocket" host="127.0.0.1" port="8080" server_type="tcp" restore="true" store="true" bidi="true"/>
+ <change_type new_type="ts_websocket" host="127.0.0.1" port="8080" server_type="tcp" restore="true" store="true" bidi="true"/>i
+
+When connecting to a websocket server you can set the ``origin``, which can be
+checked by a websocket as a security measure, see
+https://tools.ietf.org/html/rfc6455#section-10.2 for more details.
+If not set this defaults to the ``host`` value.
+
+.. code-block:: xml
+
+  <websocket type="connect" origin="https://example.com"></websocket>
 
 AMQP
 ^^^^^^^^^

--- a/include/ts_websocket.hrl
+++ b/include/ts_websocket.hrl
@@ -31,6 +31,7 @@
           type, % connect or message
           path, % connection path
           frame = "binary",
+          origin, % origin of websocket request
           subprotos = [], % subprotocols
           data % websocket data
          }).

--- a/src/lib/websocket.erl
+++ b/src/lib/websocket.erl
@@ -27,7 +27,7 @@
 -vc('$Id$ ').
 -author('jzhihui521@gmail.com').
 
--export([get_handshake/4, check_handshake/2, encode_binary/1, encode_text/1,
+-export([get_handshake/5, check_handshake/2, encode_binary/1, encode_text/1,
          encode_close/1, encode/2, decode/1]).
 
 -include("ts_profile.hrl").
@@ -37,14 +37,17 @@
 %%%===================================================================
 %%% API functions
 %%%===================================================================
-get_handshake(Host, Path, SubProtocol, Version) ->
+get_handshake(Host, Path, SubProtocol, Version, Origin) ->
     {Key, Accept} = gen_accept_key(),
     Req = list_to_binary(["GET ", Path, " HTTP/1.1\r\n",
                           "Host: ", Host ,"\r\n",
                           "Upgrade: websocket\r\n",
                           "Connection: Upgrade\r\n",
+                          "Origin: ",
+                          case Origin of "" -> Host;
+                                         _  -> Origin
+                          end, "\r\n",
                           "Sec-WebSocket-Key: ", Key, "\r\n",
-                          "Origin: http://", Host, "\r\n",
                           "Sec-WebSocket-Version: ", Version, "\r\n"]),
     SubProHeader = case SubProtocol of
         [] -> [];

--- a/src/test/ts_test_websocket.erl
+++ b/src/test/ts_test_websocket.erl
@@ -29,7 +29,7 @@
 test()->ok.
 
 handshake_test() ->
-    {_, Accept} = websocket:get_handshake("127.0.0.1", "/chat", [], 13),
+    {_, Accept} = websocket:get_handshake("127.0.0.1", "/chat", [], 13, ""),
     Response1 = ["HTTP/1.1 101 Switching Protocols\r\n",
                  "Upgrade: websocket\r\n",
                  "Connection: Upgrade\r\n",

--- a/src/tsung/ts_websocket.erl
+++ b/src/tsung/ts_websocket.erl
@@ -79,10 +79,11 @@ dump(A,B) ->
 %% Returns: binary
 %%----------------------------------------------------------------------
 get_message(#websocket_request{type = connect, path = Path,
-                               subprotos = SubProtocol, version = Version},
+                               subprotos = SubProtocol, version = Version,
+                               origin = Origin},
             State=#state_rcv{session = WebsocketSession}) ->
     {Request, Accept} = websocket:get_handshake(State#state_rcv.host, Path,
-                                                SubProtocol, Version),
+                                                SubProtocol, Version, Origin),
     {Request, WebsocketSession#websocket_session{status = waiting_handshake,
                                                  accept = Accept}};
 get_message(#websocket_request{type = message, data = Data, frame = Frame},

--- a/src/tsung_controller/ts_config_websocket.erl
+++ b/src/tsung_controller/ts_config_websocket.erl
@@ -51,12 +51,13 @@ parse_config(Element = #xmlElement{name = websocket},
     Type = ts_config:getAttr(atom, Element#xmlElement.attributes, type),
     ValRaw = ts_config:getText(Element#xmlElement.content),
     Path = ts_config:getAttr(string, Element#xmlElement.attributes, path, "/"),
+    Origin = ts_config:getAttr(string, Element#xmlElement.attributes, origin, ""),
     SubProtocols = ts_config:getAttr(string, Element#xmlElement.attributes, subprotocols, ""),
     Frame = ts_config:getAttr(string, Element#xmlElement.attributes, frame,
                               "binary"),
 
     Request = #websocket_request{data = ValRaw, type = Type, subprotos = SubProtocols,
-                                 path = Path, frame = Frame},
+                                 origin = Origin, path = Path, frame = Frame},
 
     Ack = case Type of
               message ->

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -379,6 +379,7 @@ repeat | if | change_type | foreach | set_option | interaction | abort )*>
     type (connect | message | close) #REQUIRED
     ack  (no_ack | parse) #IMPLIED
     frame (binary | text) #IMPLIED
+    origin CDATA ""
     subprotocols CDATA ""
     path CDATA "/" >
 


### PR DESCRIPTION
- changes arity of get_handshake  (4 => 5)
- adds new parameter "origin" in record #websocket_request
- adds new parameter "origin" in tsung xml-schema for websocket