### PR TITLE
tsung fails in ts_dynvars:merge when arguments are [<<>>, Dynvars]

### DIFF
--- a/src/tsung/ts_dynvars.erl
+++ b/src/tsung/ts_dynvars.erl
@@ -119,4 +119,6 @@ do_map(Fun,Key,Default,[H|Rest], Acc) ->
 %% @spec merge(DynVars::dynvars(),DynVars::dynvars()) -> dynvars()
 %% @doc merge two set of dynamic variables
 merge(DynVars1, DynVars2) when ?IS_DYNVARS(DynVars1),?IS_DYNVARS(DynVars2) ->
-    ts_utils:keyumerge(1,DynVars1,DynVars2).
+    ts_utils:keyumerge(1,DynVars1,DynVars2);
+merge(_, DynVars2) -> DynVars2.
+


### PR DESCRIPTION
Hi!

ts_dynvars:merge function implementation is unsafe because it does not provide alternative for error case. 

For example, in case if 'dynvars' enabled and there is no variable substitutions detected it crashes because it fails to merge empty buffer with existed Dynvars. This happens when i mix variable substitution on and off in different requests in one transaction

Regards,
Igor