### PR TITLE
add forwarding latency statistic for mqtt

### DIFF
--- a/docs/conf-sessions.rst
+++ b/docs/conf-sessions.rst
@@ -1035,6 +1035,27 @@ Example with MQTT as a session type:
 
 Note that if a ``client_id`` is omitted upon connecting Tsung will create a random one, prefixed with ``tsung-``.
 
+Message stamping
+""""""""""""""""
+
+It is possible to stamp measure the broker's forwarding latency by setting
+``stamped`` attribute inside ``<publish>`` element to ``true``. The stamp
+will include current timestamp and ID of the sender node. If the recipient
+will recognize the node ID, it will compare the timestamp inside message
+with the current one. The difference will be reported as ``mqtt_forward_latency``
+metric (in milliseconds). The aim of node ID comparison is to avoid slight
+inconsistencies of timestamps on different Tsung nodes.
+
+Only a fraction of requests will hit the same node they originated from,
+but with request rate high enough this fraction should be sufficient.
+
+``stamped`` is allowed only with ``size`` attribute. ``data`` will cause
+``stamped`` to be ignored. There is a minimal length of the stamp,
+roughly 30 bytes. When ``size`` is greater than stamp length, random
+padding will be added to the stamp. If the stamp length is higher than
+``size``, then only stamp will be used as messagecontent, effectively
+exceeding specified length.
+
 LDAP
 ^^^^
 

--- a/docs/conf-sessions.rst
+++ b/docs/conf-sessions.rst
@@ -1011,7 +1011,7 @@ Example with MQTT as a session type:
 
         <for from="1" to="10" incr="1" var="loops">
             <request subst="true">
-                <mqtt type="publish" topic="test_topic" qos="1" retained="true">test_message</mqtt>
+                <mqtt type="publish" topic="test_topic" qos="1" retained="true" stamped="false">test_message</mqtt>
             </request>
         </for>
 

--- a/docs/conf-sessions.rst
+++ b/docs/conf-sessions.rst
@@ -1053,7 +1053,7 @@ but with request rate high enough this fraction should be sufficient.
 ``stamped`` to be ignored. There is a minimal length of the stamp,
 roughly 30 bytes. When ``size`` is greater than stamp length, random
 padding will be added to the stamp. If the stamp length is higher than
-``size``, then only stamp will be used as messagecontent, effectively
+``size``, then only stamp will be used as message content, effectively
 exceeding specified length.
 
 LDAP

--- a/docs/conf-sessions.rst
+++ b/docs/conf-sessions.rst
@@ -1044,17 +1044,11 @@ will include current timestamp and ID of the sender node. If the recipient
 will recognize the node ID, it will compare the timestamp inside message
 with the current one. The difference will be reported as ``mqtt_forward_latency``
 metric (in milliseconds). The aim of node ID comparison is to avoid slight
-inconsistencies of timestamps on different Tsung nodes.
+inconsistencies of timestamps on different Tsung nodes. Note that the stamp
+will be add ahead of the publish payload and will increase publish payload size.
 
 Only a fraction of requests will hit the same node they originated from,
 but with request rate high enough this fraction should be sufficient.
-
-``stamped`` is allowed only with ``size`` attribute. ``data`` will cause
-``stamped`` to be ignored. There is a minimal length of the stamp,
-roughly 30 bytes. When ``size`` is greater than stamp length, random
-padding will be added to the stamp. If the stamp length is higher than
-``size``, then only stamp will be used as message content, effectively
-exceeding specified length.
 
 LDAP
 ^^^^

--- a/examples/mqtt.xml.in
+++ b/examples/mqtt.xml.in
@@ -24,7 +24,7 @@
 
             <for from="1" to="10" incr="1" var="loops">
                 <request subst="true">
-                    <mqtt type="publish" topic="test_topic" qos="1" retained="true">test_message</mqtt>
+                    <mqtt type="publish" topic="test_topic" qos="1" retained="true" stamped="false">test_message</mqtt>
                 </request>
             </for>
 

--- a/include/ts_mqtt.hrl
+++ b/include/ts_mqtt.hrl
@@ -40,7 +40,8 @@
           retained = false,
           payload,
           username,
-          password
+          password,
+          stamped = false
          }).
 
 -record(mqtt_dyndata, {

--- a/src/tsung/ts_mqtt.erl
+++ b/src/tsung/ts_mqtt.erl
@@ -106,16 +106,19 @@ get_message(#mqtt_request{type = disconnect},
     {mqtt_frame:encode(Message),
      MqttSession#mqtt_session{wait = none, status = disconnect}};
 get_message(#mqtt_request{type = publish, topic = Topic, qos = Qos,
-                          retained = Retained, payload = Payload},
+                          retained = Retained, payload = Payload, stamped = Stamped},
             #state_rcv{session = MqttSession = #mqtt_session{curr_id = Id}}) ->
     NewMqttSession = case Qos of
         0 -> MqttSession;
         _ -> MqttSession#mqtt_session{curr_id = Id + 1}
     end,
-
+    NewPayload = case Stamped of
+        true -> generate_stamp() ++ Payload;
+        _ -> Payload
+    end,
     MsgId = NewMqttSession#mqtt_session.curr_id,
     Message = #mqtt{id = MsgId, type = ?PUBLISH, qos = Qos, retain = Retained,
-                    arg = {Topic, Payload}},
+                    arg = {Topic, NewPayload}},
     Wait = case Qos of
         1 -> ?PUBACK;
         _ -> none
@@ -219,12 +222,13 @@ parse_bidi(<<>>, State=#state_rcv{acc = [], session = MqttSession}) ->
 parse_bidi(Data, State=#state_rcv{acc = [], session = MqttSession}) ->
     AckBuf = MqttSession#mqtt_session.ack_buf,
     case mqtt_frame:decode(Data) of
-        {_MqttMsg = #mqtt{type = ?PUBLISH, qos = Qos, id = MessageId}, Left} ->
+        {_MqttMsg = #mqtt{type = ?PUBLISH, qos = Qos, id = MessageId, arg = {_, Payload}}, Left} ->
             ?DebugF("receive bidi mqtt_msg: ~p ~p~n",
                     [mqtt_frame:command_for_type(?PUBLISH), _MqttMsg]),
 
             ts_mon_cache:add({count, mqtt_server_published}),
             ts_mon_cache:add({count, mqtt_pubacked}),
+            parse_stamp(Payload),
             Ack = case Qos of
                 1 ->
                     Message = #mqtt{type = ?PUBACK, arg = MessageId},
@@ -318,4 +322,30 @@ ping_loop(Proto, Socket, KeepAlive) ->
             erlang:send_after(KeepAlive * 1000, self(), ping),
             ping_loop(Proto, Socket, KeepAlive);
         stop -> ok
+    end.
+
+generate_stamp() ->
+    {Mega, Secs, Micro} = ?TIMESTAMP,
+    TS = integer_to_list(Mega) ++ ";"
+    ++ integer_to_list(Secs) ++ ";"
+    ++ integer_to_list(Micro),
+    "@@@" ++ integer_to_list(erlang:phash2(node())) ++ "," ++ TS ++ "@@@".
+
+parse_stamp(Payload) ->
+    case re:run(Payload, "@@@([^@]+)@@@", [{capture, all_but_first, list}]) of
+        {match, [NodeStamp]} ->
+            [NodeS, StampS] = string:tokens(NodeStamp, ","),
+            case integer_to_list(erlang:phash2(node())) of
+                NodeS ->
+                    [MegaS, SecsS, MicroS] = string:tokens(StampS, ";"),
+                    Mega = list_to_integer(MegaS),
+                    Secs = list_to_integer(SecsS),
+                    Micro = list_to_integer(MicroS),
+                    Latency = timer:now_diff(?TIMESTAMP, {Mega, Secs, Micro}),
+                    ts_mon_cache:add({ sample, mqtt_forward_latency, Latency / 1000});
+                _ ->
+                    ignore
+            end;
+        nomatch ->
+            nomatch
     end.

--- a/src/tsung_controller/ts_config_mqtt.erl
+++ b/src/tsung_controller/ts_config_mqtt.erl
@@ -70,6 +70,8 @@ parse_config(Element = #xmlElement{name = mqtt},
                             qos, 0),
     Retained = ts_config:getAttr(atom, Element#xmlElement.attributes,
                                  retained, false),
+    Stamped = ts_config:getAttr(atom, Element#xmlElement.attributes,
+                                 stamped, false),
     RetainValue = case Retained of
         true -> 1;
         false -> 0
@@ -82,7 +84,7 @@ parse_config(Element = #xmlElement{name = mqtt},
                             keepalive = KeepAlive, will_topic = WillTopic,
                             will_qos = WillQos, will_msg = WillMsg,
                             will_retain = WillRetain, topic = Topic, qos = Qos,
-                            retained = RetainValue, payload = Payload, username = UserName, password = Password},
+                            retained = RetainValue, payload = Payload, username = UserName, password = Password, stamped = Stamped},
     Ack = case {Type, Qos} of
         {publish, 0} -> no_ack;
         {disconnect, _} -> no_ack;

--- a/src/tsung_stats.pl.in
+++ b/src/tsung_stats.pl.in
@@ -400,7 +400,7 @@ sub parse_stats_file {
                 $category->{$type} = "http_status";
             } elsif ($type eq "request" or $type eq "page" or $type eq "session" or  $type eq "connect" or $type eq "async_rcv") {
                 $category->{$type} = "stats";
-            } elsif ($type =~ /^tr_/ or $type eq "page" or $type eq "xmpp_msg_latency") {
+            } elsif ($type =~ /^tr_/ or $type eq "page" or $type eq "xmpp_msg_latency" or $type eq "mqtt_forward_latency") {
                 $category->{$type} = "transaction";
             } elsif ($type =~ "^size") {
                 $category->{$type} = "network";
@@ -511,7 +511,7 @@ sub parse_stats_file {
         } elsif ($key eq "bosh_http_conn" or $key eq "bosh_http_req") {
 	    $bosh = 1;
             push @bosh_tps, "$key.txt";
-        } elsif ($key =~ /^tr_/ or $key eq "page" or $key eq "xmpp_msg_latency") {
+        } elsif ($key =~ /^tr_/ or $key eq "page" or $key eq "xmpp_msg_latency" or $key eq "mqtt_forward_latency") {
             push @transactions, "$key.txt";
         } elsif ($key =~ /^\d+$/) {
             $http = 1;
@@ -593,7 +593,7 @@ sub html_report {
                 $maxval->{$type}->{$data} = sprintf "%.2f",$maxval->{$type}->{$data};
                 next;
             }
-            next if not ($data eq "session" or $data eq "connect" or $data eq "request" or $data eq "page" or $data =~ m/^tr_/ or $data eq "xmpp_msg_latency");
+            next if not ($data eq "session" or $data eq "connect" or $data eq "request" or $data eq "page" or $data =~ m/^tr_/ or $data eq "xmpp_msg_latency" or $data eq "mqtt_forward_latency");
             $maxval->{$type}->{$data} = &formattime($maxval->{$type}->{$data});
         }
     }

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -413,7 +413,8 @@ repeat | if | change_type | foreach | set_option | interaction | abort )*>
     retained CDATA "false"
     timeout CDATA "1"
     username CDATA ""
-    password CDATA "">
+    password CDATA ""
+    stamped (true | false) "false" >
 
 <!ELEMENT modification (attr*) >
 <!ATTLIST modification


### PR DESCRIPTION
Hi,
I have add the "stamped" label for mqtt publish request which can give a measurement for the message forwarding latency between publish time and receive time. Same as xmpp_msg_latency in Jabber module.
As we know, mqtt is mainly used in IOT environment, e.g., use the mobile device to control some house appliance. So the forwarding latency is quite a performance target to evaluate a mqtt broker.
Usage:
make stamped="true" in mqtt.xml, i.e.,
<mqtt type="publish" topic="test_topic" qos="1" retained="true" _stamped="false"_>test_message</mqtt>