### PR TITLE
Add custom headers with websocket request

### DIFF
--- a/docs/conf-sessions.rst
+++ b/docs/conf-sessions.rst
@@ -889,6 +889,16 @@ If not set this defaults to the ``host`` value.
 
   <websocket type="connect" origin="https://example.com"></websocket>
 
+**New in 1.7.1**: You can also add any HTTP header now, as in:
+
+.. code-block:: xml
+
+  <request subst="true">
+    <websocket type="connect" path="/path/to/ws">
+      <http_header name="Cookie" value="sessionid=%%_sessionid%%"/>
+    </websocket>
+  </request>
+
 AMQP
 ^^^^^^^^^
 .. _sec-session-amqp-label:

--- a/include/ts_websocket.hrl
+++ b/include/ts_websocket.hrl
@@ -33,6 +33,7 @@
           frame = "binary",
           origin, % origin of websocket request
           subprotos = [], % subprotocols
+          headers = [], % additional headers
           data % websocket data
          }).
 

--- a/src/test/ts_test_websocket.erl
+++ b/src/test/ts_test_websocket.erl
@@ -29,7 +29,7 @@
 test()->ok.
 
 handshake_test() ->
-    {_, Accept} = websocket:get_handshake("127.0.0.1", "/chat", [], 13, ""),
+    {_, Accept} = websocket:get_handshake("127.0.0.1", "/chat", [], 13, "", []),
     Response1 = ["HTTP/1.1 101 Switching Protocols\r\n",
                  "Upgrade: websocket\r\n",
                  "Connection: Upgrade\r\n",

--- a/src/tsung_controller/ts_config_http.erl
+++ b/src/tsung_controller/ts_config_http.erl
@@ -32,7 +32,8 @@
 -author('nicolas.niclausse@niclux.org').
 
 -export([parse_config/2, parse_URL/1, set_port/1, set_scheme/1,
-         check_user_agent_sum/1, set_query/1, encode_ipv6_address/1]).
+         check_user_agent_sum/1, set_query/1, encode_ipv6_address/1,
+         parse_headers/2]).
 
 -include("ts_profile.hrl").
 -include("ts_http.hrl").
@@ -209,6 +210,12 @@ get_previous_http_server(Ets, Id) ->
         [{_Key,PrevServ}] -> PrevServ
     end.
 
+%%----------------------------------------------------------------------
+%% Func: parse_headers/2
+%% Args: Elements (list), Headers (list)
+%% Returns: List
+%% Purpose: parse http_header elements
+%%----------------------------------------------------------------------
 parse_headers([], Headers) ->
     Headers;
 parse_headers([Element = #xmlElement{name=http_header} | Tail], Headers) ->

--- a/src/tsung_controller/ts_config_websocket.erl
+++ b/src/tsung_controller/ts_config_websocket.erl
@@ -55,9 +55,10 @@ parse_config(Element = #xmlElement{name = websocket},
     SubProtocols = ts_config:getAttr(string, Element#xmlElement.attributes, subprotocols, ""),
     Frame = ts_config:getAttr(string, Element#xmlElement.attributes, frame,
                               "binary"),
+    Headers = ts_config_http:parse_headers(Element#xmlElement.content, []),
 
     Request = #websocket_request{data = ValRaw, type = Type, subprotos = SubProtocols,
-                                 origin = Origin, path = Path, frame = Frame},
+                                 origin = Origin, path = Path, frame = Frame, headers = Headers},
 
     Ack = case Type of
               message ->

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -374,7 +374,7 @@ repeat | if | change_type | foreach | set_option | interaction | abort )*>
     certfile    CDATA   #IMPLIED
     dn          CDATA   #IMPLIED
     >
-<!ELEMENT websocket (#PCDATA) >
+<!ELEMENT websocket (#PCDATA | http_header)* >
 <!ATTLIST websocket
     type (connect | message | close) #REQUIRED
     ack  (no_ack | parse) #IMPLIED


### PR DESCRIPTION
This is a patch to resolve #116 . It parses custom headers from content of a ```websocket``` tag with type ```connect```, and send them with the handshake request. For example, we can send custom cookie using the following config:

```
<request subst="true">
  <websocket type="connect" path="/path/to/ws">
    Cookie: sessionid=%%_sessionid%%
  </websocket>
</request>
```

I'm new to Erlang. Could any maintainer give me some feedback? If the design is acceptable, I'd like to complete the document.