### PR TITLE
Fix: <if> and <repeat> does not work with lte and gte

### DIFF
--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -494,9 +494,9 @@ parse(_Element = #xmlElement{name='if', attributes=Attrs,content=Content},
                       {none, none, none, Lt, none, none} ->
                           {lt,Lt};
                       {none, none, none, none, Gte, none} ->
-                          {gt,Gte};
+                          {gte,Gte};
                       {none, none, none, none, none, Lte} ->
-                          {lt,Lte}
+                          {lte,Lte}
                   end,
     ?LOGF("Add if_start action in session ~p as id ~p",
           [CurS#session.id,Id+1],?INFO),
@@ -588,9 +588,9 @@ parse(_Element = #xmlElement{name=repeat,attributes=Attrs,content=Content},
                               {none, none, none, Lt, none, none} ->
                                   {lt,Lt};
                               {none, none, none, none, Gte, none} ->
-                                  {gt,Gte};
+                                  {gte,Gte};
                               {none, none, none, none, none, Lte} ->
-                                  {lt,Lte}
+                                  {lte,Lte}
                           end,
                           %either <while .. eq=".."/> , <while ..neq=".."/>
                           %either <while .. gt=".."/> , <while ..gte=".."/>


### PR DESCRIPTION
As far as I can tell this might never have been working properly, which still strikes me as odd.

Anyway, I noticed that `<if var="my_variable" gte="400">` only worked for values of `400` or larger. It turns that `ts_client:parse` for `if` and `repeat` does properly parse the XML, but then fails to assign the correct value to `Rel`.