### PR TITLE
Fix ts_config_http:parse_URL/4 to deal with empty paths

### DIFF
--- a/src/tsung_controller/ts_config_http.erl
+++ b/src/tsung_controller/ts_config_http.erl
@@ -398,6 +398,8 @@ parse_URL(host, [], Acc, URL) -> % no path or port
     URL#url{host=lists:reverse(Acc), path= "/"};
 parse_URL(host, [$/|Tail], Acc, URL) -> % path starts here
     parse_URL(path, Tail, "/", URL#url{host=lists:reverse(Acc)});
+parse_URL(host, [$?|Tail], Acc, URL) -> % path/query starts here
+    parse_URL(path, "?" ++ Tail, "/", URL#url{host=lists:reverse(Acc)});
 parse_URL(host, [$:|Tail], Acc, URL) -> % port starts here
     parse_URL(port, Tail, [], URL#url{host=lists:reverse(Acc)});
 parse_URL(host, [H|Tail], Acc, URL) ->


### PR DESCRIPTION
This is a fix to address https://github.com/processone/tsung/issues/227

For URLs with an empty path, like `http://example.com?foo=bar`, we used to see this when using a dynamic URL for making a HTTP request (as reported by @adrian7):

```
=INFO REPORT==== 16-Jun-2018::19:10:21 ===
             ts_http:(6:<0.158.0>) URL dynamic subst: {url,http,
                                                       "example.com?foo=bar",
                                                       undefined,"/",[]}
```

It turns out `ts_config_http:parse_URL/4` does not stop at `?` when trying to identify the host in a given absolute URL.

With this PR, `ts_config_http:parse_URL/4` now properly detects that the host part has been finished (because we encounter the `?`) and produces an empty path instead. We have to set `URL#url{path="/"};` because otherwise we will produce an invalid HTTP request like: `GET ?foo=bar HTTP/1.1`

```
=INFO REPORT==== 16-Jun-2018::19:07:20 ===
             ts_http:(6:<0.158.0>) URL dynamic subst: {url,http,
                                                       "example.com",
                                                       undefined,"/",
                                                       "foo=bar"}
```