### PR TITLE
Run <if> value by ts_search:subst/2

### DIFF
--- a/src/tsung/ts_client.erl
+++ b/src/tsung/ts_client.erl
@@ -647,8 +647,9 @@ ctrl_struct_impl({if_start,Rel, VarName, Value, Target},DynVars) ->
     case ts_dynvars:lookup(VarName,DynVars) of
         {ok,VarValue} ->
             ?DebugF("If found ~p; value is ~p~n",[VarName,VarValue]),
-            ?DebugF("Calling need_jump with args ~p ~p ~p~n",[Rel,Value,VarValue]),
-            Jump = need_jump('if',rel(Rel,Value,VarValue)),
+            NewValue = ts_search:subst(Value, DynVars),
+            ?DebugF("Calling need_jump with args ~p ~p ~p~n",[Rel,NewValue,VarValue]),
+            Jump = need_jump('if',rel(Rel,NewValue,VarValue)),
             jump_if(Jump,Target,DynVars);
         false ->
             ts_mon_cache:add({ count, 'error_if_undef'}),

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -503,11 +503,9 @@ parse(_Element = #xmlElement{name='if', attributes=Attrs,content=Content},
     NewConf = lists:foldl(fun parse/2, Conf#config{curid=Id+1}, Content),
     NewId = NewConf#config.curid,
     ?LOGF("endif in session ~p as id ~p",[CurS#session.id,NewId+1],?INFO),
-    SubstitutionFlag = case string:str(Value, "%%") of
-                         Pos when Pos > 0 ->
-                           subst;
-                         Pos when Pos =:= 0 ->
-                           nosubst
+    SubstitutionFlag = case re:run(Value, "%%.+%%") of
+                         {match, _} -> subst;
+                         nomatch -> nosubst
                        end,
     InitialAction = {ctrl_struct, {if_start, Rel, VarName, list_to_binary(Value), SubstitutionFlag, NewId+1}},
     %%NewId+1 -> id of the first action after the if

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -503,7 +503,13 @@ parse(_Element = #xmlElement{name='if', attributes=Attrs,content=Content},
     NewConf = lists:foldl(fun parse/2, Conf#config{curid=Id+1}, Content),
     NewId = NewConf#config.curid,
     ?LOGF("endif in session ~p as id ~p",[CurS#session.id,NewId+1],?INFO),
-    InitialAction = {ctrl_struct, {if_start, Rel, VarName, list_to_binary(Value) , NewId+1}},
+    SubstitutionFlag = case string:str(Value, "%%") of
+                         Pos when Pos > 0 ->
+                           subst;
+                         Pos when Pos =:= 0 ->
+                           nosubst
+                       end,
+    InitialAction = {ctrl_struct, {if_start, Rel, VarName, list_to_binary(Value), SubstitutionFlag, NewId+1}},
     %%NewId+1 -> id of the first action after the if
     ets:insert(Tab,{{CurS#session.id,Id+1},InitialAction}),
     NewConf;


### PR DESCRIPTION
This PR will run the `value` of `<if>` by `ts_search:subst/2` to make it work with variables as well.

For example, if you need to compare a variable against another variable that you've extracted from a previous request, you can now do that.

Example:

```xml
<request>
  <dyn_variable name="extracted_token" re="X-CSRF-Token: (https?://.*)&#13;"/>
  <http url="http://example.com/login" method="GET" version="1.1">
  </http>
</request>

<!-- make some more request -->

<request>
  <dyn_variable name="current_token" re="X-CSRF-Token: (https?://.*)&#13;"/>
  <http url="http://example.com/basket" method="GET" version="1.1">
  </http>
</request>


<!-- abort current client in case tokens do not match and you cannot proceed -->

<if var="current_token" neq="%%_extracted_token%%">
  <abort type="session"/>
</if>
```

Fixes https://github.com/processone/tsung/issues/168