### PR TITLE
Substitution in <dyn_variable>

### DIFF
--- a/docs/conf-advanced-features.rst
+++ b/docs/conf-advanced-features.rst
@@ -323,7 +323,7 @@ only for the HTTP plugin. This feature uses the mochiweb library and
 Tsung implements a (very) limited subset of JSONPath as defined here
 http://goessner.net/articles/JsonPath/
 
-To utilize jsonpath expression, use a **jsonpath** attribute when
+To utilize JSONPath expression, use a **jsonpath** attribute when
 defining the ``<dyn_variable>>``, instead of ``re``, like:
 
 .. code-block:: xml
@@ -336,6 +336,12 @@ You can also use expressions ``Key=Val``, e.g.:
 .. code-block:: xml
 
    <dyn_variable name="myvar" jsonpath="field.array[?name=bar].value"/>
+
+
+Starting with version **1.8.0** you can use variables to be substituted
+in your JSONPath expression. This requires the surrounding ``<request>`` to have
+set ``subst="true"``. Otherwise the JSONPath expression will be taken
+literally.
 
 
 PostgreSQL

--- a/src/test/ts_test_search.erl
+++ b/src/test/ts_test_search.erl
@@ -101,6 +101,27 @@ parse_dyn_var_jsonpath_struct_test() ->
     JSONPath = "accessToken",
     ?assertMatch([{'nodes',  << "{\"id\":\"78548a96-cadd-48c0-b7d6-4ff3b81f10cc\",\"lists\":[\"testlist1\"],\"token\":\"rTgdC3f7uJ/Smg3s4b9va2KW5GdPkRHtwYNgWbvwhensgOSf2/wan95VPDiXKnAAGilsZlpw/Td4bs/OPeVeYg==\",\"scope\":[\"GET_ME\",\"WRITE_ACCESS\"]}" >> }], ts_search:parse_dynvar([{jsonpath,'nodes', JSONPath, false} ],list_to_binary(Data))).
 
+parse_dyn_var_jsonpath_dynamic_test() ->
+    myset_env(),
+    Data="\r\n\r\n{\"titi\": [{\"val\": 123, \"name\": \"foo\"}, {\"val\": 42, \"name\": \"bar\"}]}",
+    JSONPath = "titi[?name=%%_name%%].val",
+    DynVars = ts_dynvars:new(name, "bar"),
+    ?assertEqual([{'myvar',42}, {'name', "bar"}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, true} ],list_to_binary(Data), DynVars)).
+
+parse_dyn_var_jsonpath_dynamic_disabled_test() ->
+    myset_env(),
+    Data="\r\n\r\n{\"titi\": [{\"val\": 123, \"name\": \"foo\"}, {\"val\": 42, \"name\": \"bar\"}]}",
+    JSONPath = "titi[?name=%%_name%%].val",
+    DynVars = ts_dynvars:new(name, "bar"),
+    ?assertEqual([{'myvar', <<>>}, {'name', "bar"}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data), DynVars)).
+
+parse_dyn_var_jsonpath_dynamic_enabled_nothing_to_subst_test() ->
+    myset_env(),
+    Data="\r\n\r\n{\"titi\": [{\"val\": 123, \"name\": \"foo\"}, {\"val\": 42, \"name\": \"bar\"}]}",
+    JSONPath = "titi[?name=foo].val",
+    DynVars = ts_dynvars:new(),
+    ?assertEqual([{'myvar',123}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data), DynVars)).
+
 
 parse_dyn_var_xpath_test() ->
     myset_env(),

--- a/src/test/ts_test_search.erl
+++ b/src/test/ts_test_search.erl
@@ -30,37 +30,37 @@ parse_dyn_var_jsonpath_test() ->
     myset_env(),
     Data="\r\n\r\n{\"titi\": [23,45]}",
     JSONPath = "titi[1]",
-    ?assertEqual([{'myvar',45}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))).
+    ?assertEqual([{'myvar',45}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath2_test() ->
     myset_env(),
     Data="\r\n\r\n{\"titi\": [23,45]}",
     JSONPath = "titi[3]",
-    ?assertEqual([{'myvar',<< >>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))).
+    ?assertEqual([{'myvar',<< >>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath3_test() ->
     myset_env(),
     Data="\r\n\r\n{\"titi\": [{\"val\": 123, \"name\": \"foo\"}, {\"val\": 42, \"name\": \"bar\"}]}",
     JSONPath = "titi[?name=bar].val",
-    ?assertEqual([{'myvar',42}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))).
+    ?assertEqual([{'myvar',42}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath4_test() ->
     myset_env(),
     Data="\r\n\r\n{\"titi\": [{\"val\": 123, \"name\": \"foo\"}, {\"val\": 42, \"name\": \"bar\"}]}",
     JSONPath = "titi[?name=void].val",
-    ?assertEqual([{'myvar', << >>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))).
+    ?assertEqual([{'myvar', << >>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath5_test() ->
     myset_env(),
     Data="\r\n\r\n{\"titi\": [{\"val\": 123, \"status\": \"foo\"}, {\"val\": 42, \"status\": \"OK\"}, {\"val\": 48, \"status\": \"OK\"}]}",
     JSONPath = "titi[?status=OK].val",
-    ?assertEqual([{'myvar',[42,48]}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))).
+    ?assertEqual([{'myvar',[42,48]}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath6_test() ->
     myset_env(),
     Data="\r\n\r\n{\"titi\": [{\"val\": 123, \"name\": \"foo\"}, {\"val\": 42, \"name\": \"bar\"}]}",
     JSONPath = "titi[*].val",
-    ?assertEqual([{'myvar',[123,42]}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))).
+    ?assertEqual([{'myvar',[123,42]}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath7_test() ->
     myset_env(),
@@ -79,27 +79,27 @@ parse_dyn_var_jsonpath7_test() ->
                 }
         }",
     JSONPath = "menu.popup.name",
-    ?assertEqual([{'myvar', << "glop" >>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))),
+    ?assertEqual([{'myvar', << "glop" >>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data))),
     JSONPathTab = "menu.popup.menuitem[0].value",
-    ?assertEqual([{'myvar', << "New" >>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPathTab} ],list_to_binary(Data))).
+    ?assertEqual([{'myvar', << "New" >>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPathTab, false} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath_int_test() ->
     myset_env(),
     Data="\r\n\r\n{\"titi\": [{\"val\": 123, \"name\": \"foo\"}, {\"val\": 42, \"name\": \"bar\"}]}",
     JSONPath = "titi[?val=123].name",
-    ?assertEqual([{'myvar',<<"foo">>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath} ],list_to_binary(Data))).
+    ?assertEqual([{'myvar',<<"foo">>}], ts_search:parse_dynvar([{jsonpath,'myvar', JSONPath, false} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath_xmpp_test() ->
     myset_env(),
     Data="{\n  \"status\": \"terminated\",\n  \"uid\": \"944370dc04adbee1792732e01097e618af97cc27\",\n  \"updated_at\": 1282660758,\n  \"nodes\": [\n    \"suno-12\",\n    \"suno-13\"\n  ],\n  \"created_at\": 1282660398,\n  \"environment\": \"lenny-x64-big\",\n  \"result\": {\n    \"suno-13\": {\n      \"last_cmd_stdout\": \"\",\n      \"last_cmd_stderr\": \"\",\n      \"cluster\": \"suno\",\n      \"ip\": \"192.168.1.113\",\n      \"last_cmd_exit_status\": 0,\n      \"current_step\": null,\n      \"state\": \"OK\"\n    },\n    \"suno-12\": {\n      \"last_cmd_stdout\": \"\",\n      \"last_cmd_stderr\": \"\",\n      \"cluster\": \"suno\",\n      \"ip\": \"192.168.1.112\",\n      \"last_cmd_exit_status\": 0,\n      \"current_step\": null,\n      \"state\": \"OK\"\n    }\n  },\n  \"site_uid\": \"sophia\",\n  \"notifications\": [\n    \"xmpp:joe@foo.bar/tsung\"\n  ],\n  \"user_uid\": \"joe\"\n}",
     JSONPath = "nodes",
-    ?assertMatch([{'nodes',[<<"suno-12">>,<<"suno-13">>]}], ts_search:parse_dynvar([{jsonpath,'nodes', JSONPath} ],list_to_binary(Data))).
+    ?assertMatch([{'nodes',[<<"suno-12">>,<<"suno-13">>]}], ts_search:parse_dynvar([{jsonpath,'nodes', JSONPath, false} ],list_to_binary(Data))).
 
 parse_dyn_var_jsonpath_struct_test() ->
     myset_env(),
     Data="{\"accessToken\":{\"id\":\"78548a96-cadd-48c0-b7d6-4ff3b81f10cc\",\"lists\":[\"testlist1\"],\"token\":\"rTgdC3f7uJ/Smg3s4b9va2KW5GdPkRHtwYNgWbvwhensgOSf2/wan95VPDiXKnAAGilsZlpw/Td4bs/OPeVeYg==\",\"scope\":[\"GET_ME\",\"WRITE_ACCESS\"]},\"accessTokenSignature\":\"gWAL+zvDcQjqLmNdSwcG/TOWyta5g==\"}",
     JSONPath = "accessToken",
-    ?assertMatch([{'nodes',  << "{\"id\":\"78548a96-cadd-48c0-b7d6-4ff3b81f10cc\",\"lists\":[\"testlist1\"],\"token\":\"rTgdC3f7uJ/Smg3s4b9va2KW5GdPkRHtwYNgWbvwhensgOSf2/wan95VPDiXKnAAGilsZlpw/Td4bs/OPeVeYg==\",\"scope\":[\"GET_ME\",\"WRITE_ACCESS\"]}" >> }], ts_search:parse_dynvar([{jsonpath,'nodes', JSONPath} ],list_to_binary(Data))).
+    ?assertMatch([{'nodes',  << "{\"id\":\"78548a96-cadd-48c0-b7d6-4ff3b81f10cc\",\"lists\":[\"testlist1\"],\"token\":\"rTgdC3f7uJ/Smg3s4b9va2KW5GdPkRHtwYNgWbvwhensgOSf2/wan95VPDiXKnAAGilsZlpw/Td4bs/OPeVeYg==\",\"scope\":[\"GET_ME\",\"WRITE_ACCESS\"]}" >> }], ts_search:parse_dynvar([{jsonpath,'nodes', JSONPath, false} ],list_to_binary(Data))).
 
 
 parse_dyn_var_xpath_test() ->

--- a/src/tsung/ts_client.erl
+++ b/src/tsung/ts_client.erl
@@ -1296,17 +1296,17 @@ update_stats(S=#state_rcv{size_mon_thresh=T,page_timestamp=PageTime,
                      { sum, size_rcv, Datasize}]
             end,
     Request = S#state_rcv.request,
-    NewDynVars = ts_search:parse_dynvar(Request#ts_request.dynvar_specs,
+    DynVars = ts_search:parse_dynvar(Request#ts_request.dynvar_specs,
                                      S#state_rcv.buffer,
                                      S#state_rcv.dynvars),
     case Request#ts_request.endpage of
         true -> % end of a page, compute page reponse time
             PageElapsed = ts_utils:elapsed(PageTime, Now),
             ts_mon_cache:add(lists:append([Stats,[{sample, page, PageElapsed}]])),
-            {0, NewDynVars, Elapsed};
+            {0, DynVars, Elapsed};
         _ ->
             ts_mon_cache:add(Stats),
-            {PageTime, NewDynVars, Elapsed}
+            {PageTime, DynVars, Elapsed}
     end.
 
 filter(false,undefined) ->

--- a/src/tsung/ts_client.erl
+++ b/src/tsung/ts_client.erl
@@ -1296,16 +1296,17 @@ update_stats(S=#state_rcv{size_mon_thresh=T,page_timestamp=PageTime,
                      { sum, size_rcv, Datasize}]
             end,
     Request = S#state_rcv.request,
-    DynVars = ts_search:parse_dynvar(Request#ts_request.dynvar_specs,
-                                     S#state_rcv.buffer),
+    NewDynVars = ts_search:parse_dynvar(Request#ts_request.dynvar_specs,
+                                     S#state_rcv.buffer,
+                                     S#state_rcv.dynvars),
     case Request#ts_request.endpage of
         true -> % end of a page, compute page reponse time
             PageElapsed = ts_utils:elapsed(PageTime, Now),
             ts_mon_cache:add(lists:append([Stats,[{sample, page, PageElapsed}]])),
-            {0, DynVars, Elapsed};
+            {0, NewDynVars, Elapsed};
         _ ->
             ts_mon_cache:add(Stats),
-            {PageTime, DynVars, Elapsed}
+            {PageTime, NewDynVars, Elapsed}
     end.
 
 filter(false,undefined) ->

--- a/src/tsung/ts_search.erl
+++ b/src/tsung/ts_search.erl
@@ -32,7 +32,7 @@
 -module(ts_search).
 -vc('$Id$ ').
 
--export([subst/2, match/5, parse_dynvar/2]).
+-export([subst/2, match/5, parse_dynvar/2, parse_dynvar/3]).
 
 -include("ts_macros.hrl").
 -include("ts_profile.hrl").
@@ -261,17 +261,20 @@ setcount(#match{do=abort_test,name=Name}, {Count,MaxC,SessionId,UserId}, Stats,_
 %% @doc Look for dynamic variables in Data
 %% @end
 %%----------------------------------------------------------------------
-parse_dynvar([], _Data) -> ts_dynvars:new();
-parse_dynvar(DynVarSpecs, Data)  when is_binary(Data) ->
+parse_dynvar(Specs, Data) ->
+    parse_dynvar(Specs, Data, ts_dynvars:new()).
+
+parse_dynvar([], _Data, DynVars) -> DynVars;
+parse_dynvar(DynVarSpecs, Data, DynVars)  when is_binary(Data) ->
     ?DebugF("Parsing Dyn Variable (specs=~p); data is ~p~n",[DynVarSpecs,Data]),
-    parse_dynvar(DynVarSpecs,Data, undefined,undefined,[]);
-parse_dynvar(DynVarSpecs, {_,_,_,Data})  when is_binary(Data) ->
+    parse_dynvar(DynVarSpecs,Data, undefined,undefined,DynVars);
+parse_dynvar(DynVarSpecs, {_,_,_,Data}, DynVars)  when is_binary(Data) ->
     ?DebugF("Parsing Dyn Variable (specs=~p); data is ~p~n",[DynVarSpecs,Data]),
-    parse_dynvar(DynVarSpecs,Data, undefined,undefined,[]);
-parse_dynvar(DynVarSpecs, {_,_,_,Data})  when is_list(Data) ->
+    parse_dynvar(DynVarSpecs,Data, undefined,undefined,DynVars);
+parse_dynvar(DynVarSpecs, {_,_,_,Data}, DynVars)  when is_list(Data) ->
     ?DebugF("Parsing Dyn Variable (specs=~p); data is ~p~n",[DynVarSpecs,Data]),
-    parse_dynvar(DynVarSpecs,list_to_binary(Data), undefined,undefined,[]);
-parse_dynvar(DynVarSpecs, _Data)  ->
+    parse_dynvar(DynVarSpecs,list_to_binary(Data), undefined,undefined,DynVars);
+parse_dynvar(DynVarSpecs, _Data, _DynVars)  ->
     ?LOGF("Error while Parsing dyn Variable(~p)~n",[DynVarSpecs],?WARN),
     ts_dynvars:new().
 

--- a/src/tsung/ts_utils.erl
+++ b/src/tsung/ts_utils.erl
@@ -878,7 +878,6 @@ json_get_bin([<<"?",Expr/binary>> | Keys],L) when  is_list(L) ->
                                     binary_to_list(Other) =:= Val
                             end
                   end,
-            ?LOG("ok~n",?ERR),
             case lists:filter(Fun,L) of
                 [] ->
                     undefined;

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -614,7 +614,7 @@ parse(_Element = #xmlElement{name=repeat,attributes=Attrs,content=Content},
 
 %%% Parsing the dyn_variable element
 parse(#xmlElement{name=dyn_variable, attributes=Attrs},
-      Conf=#config{sessions=[CurS|_],dynvar=DynVars}) ->
+      Conf=#config{sessions=[CurS|_],dynvar=DynVars,subst=SubstitutionFlag}) ->
     StrName  = ts_utils:clean_str(getAttr(Attrs, name)),
     {ok, [{atom,_,Name}],_} = erl_scan:string("'"++StrName++"'"),
     {Type,Expr} = case {getAttr(string,Attrs,re,none),
@@ -655,6 +655,9 @@ parse(#xmlElement{name=dyn_variable, attributes=Attrs},
                      ?LOGF("Add new xpath: ~s ~n", [Expr],?INFO),
                      CompiledXPathExp = mochiweb_xpath:compile_xpath(FlattenExpr),
                      {xpath,Name,CompiledXPathExp};
+                 jsonpath ->
+                     ?LOGF("Add new jsonpath: ~s ~n", [Expr],?INFO),
+                     {jsonpath,Name,Expr,SubstitutionFlag};
                  _Other ->
                      ?LOGF("Add ~s ~s ~p ~n", [Type,Name,Expr],?INFO),
                      {Type,Name,Expr}

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -657,12 +657,12 @@ parse(#xmlElement{name=dyn_variable, attributes=Attrs},
                      {xpath,Name,CompiledXPathExp};
                  jsonpath ->
                      ?LOGF("Add new jsonpath: ~s ~n", [Expr],?INFO),
-                     EnableSubstition = case {SubstitutionFlag, re:run(Expr, "%%.+%%")} of
+                     EnableSubstitution = case {SubstitutionFlag, re:run(Expr, "%%.+%%")} of
                                             { true, { match, _ } } -> true;
                                             _ -> false
                                         end,
 
-                     {jsonpath,Name,Expr,EnableSubstition};
+                     {jsonpath,Name,Expr,EnableSubstitution};
                  _Other ->
                      ?LOGF("Add ~s ~s ~p ~n", [Type,Name,Expr],?INFO),
                      {Type,Name,Expr}

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -657,7 +657,12 @@ parse(#xmlElement{name=dyn_variable, attributes=Attrs},
                      {xpath,Name,CompiledXPathExp};
                  jsonpath ->
                      ?LOGF("Add new jsonpath: ~s ~n", [Expr],?INFO),
-                     {jsonpath,Name,Expr,SubstitutionFlag};
+                     EnableSubstition = case {SubstitutionFlag, re:run(Expr, "%%.+%%")} of
+                                            { true, { match, _ } } -> true;
+                                            _ -> false
+                                        end,
+
+                     {jsonpath,Name,Expr,EnableSubstition};
                  _Other ->
                      ?LOGF("Add ~s ~s ~p ~n", [Type,Name,Expr],?INFO),
                      {Type,Name,Expr}


### PR DESCRIPTION
Proposal for https://github.com/processone/tsung/issues/316

This PR propagates the substitution flag from `<request subst="…">` into the dynvar specification used in `ts_search:parse_dynvar`. **NOTE** Only `jsonpath` has been adjusted currently as they don't need to compile. The performance impact should be minimal.

It was necessary to pass the current `DynVars` into `ts_search:parse_dynvar` so the arity was changed from 2 to 3. For compatibility reasons (tests mainly) `ts_search:parse_dynvar/2` is now also present with the same behaviour as before. `ts_search:parse_dynvar/3` is now used by `ts_client:update_stats` and it is the main point of entry.

This PR basically allows us to have this working, which works a lot more as expected to the user:

```xml
<request subst="true">
  <dyn_variable name="title1" jsonpath="$.slideshow.slides[?title==%%_title%%].type"/>
  <http url="https://httpbin.org/json" method="GET" version="1.1">
  </http>
</request>
```

Note, that the substitution is only performed, when the `subst` attribute is set to `true` and we detect a variable inside the expression (`%%*%%`).

## Example

```xml
<setdynvars sourcetype="value" value="Overview">
  <var name="title"/>
</setdynvars>

<!-- substitutions are enabled and actually activated, because %%*%% was detected -->
<request subst="true">
  <dyn_variable name="title1" jsonpath="$.slideshow.slides[?title==%%_title%%].type"/>
  <http url="https://httpbin.org/json" method="GET" version="1.1">
  </http>
</request>

<!-- nothing will be substitute, the jsonpath is taken literally -->
<request>
  <dyn_variable name="title2" jsonpath="$.slideshow.slides[?title==%%_title%%].type"/>
  <http url="https://httpbin.org/json" method="GET" version="1.1">
  </http>
</request>

<!-- substitutions are enabled but there isn't anything to substitute (internally no sub ist attempted) -->
<request subst="true">
  <dyn_variable name="title3" jsonpath="$.slideshow.title"/>
  <http url="https://httpbin.org/json" method="GET" version="1.1">
  </http>
</request>
```

JSON document returned by https://httpbin.org/json:

```json
{
    "slideshow": {
        "author": "Yours Truly",
        "date": "date of publication",
        "slides": [{
                "title": "Wake up to WonderWidgets!",
                "type": "all"
            },
            {
                "items": [
                    "Why <em>WonderWidgets</em> are great",
                    "Who <em>buys</em> WonderWidgets"
                ],
                "title": "Overview",
                "type": "all"
            }
        ],
        "title": "Sample Slide Show"
    }
}
```

Will produce:

```
ts_search:(6:<0.158.0>) Dyn Var: Match (title1=<<"all">>),
…
ts_search:(5:<0.158.0>) Dyn Var: no Match (varname=title2),
…
ts_search:(6:<0.158.0>) Dyn Var: Match (title3=<<"Sample Slide Show">>),
…
```

## How to proceed?

1. I'd like to see if this approach is desirable or not
1. I'd like to propose to start first with only one type of substitution. Mainly because other types require pre-compilation of the used expression where we probably want to be a bit more careful.