### PR TITLE
reduce loglevel for xpath page parsing errors

### DIFF
--- a/src/tsung/ts_search.erl
+++ b/src/tsung/ts_search.erl
@@ -361,6 +361,7 @@ parse_dynvar(D=[{xpath,_VarName, _Expr}| _DynVarsSpecs],
         Type:Exp ->
             ?LOGF("Page couldn't be parsed:(~p:~p) ~n Page:~p~n",
                     [Type,Exp,Binary],?ERR),
+            ts_mon_cache:add({ count, error_xml_unparsable }),
             parse_dynvar(D,Binary,String,xpath_error,DynVars)
     end;
 

--- a/src/tsung/ts_search.erl
+++ b/src/tsung/ts_search.erl
@@ -360,7 +360,7 @@ parse_dynvar(D=[{xpath,_VarName, _Expr}| _DynVarsSpecs],
     catch
         Type:Exp ->
             ?LOGF("Page couldn't be parsed:(~p:~p) ~n Page:~p~n",
-                    [Type,Exp,Binary],?ERR),
+                    [Type,Exp,Binary],?NOTICE),
             ts_mon_cache:add({ count, error_xml_unparsable }),
             parse_dynvar(D,Binary,String,xpath_error,DynVars)
     end;


### PR DESCRIPTION
Like with https://github.com/processone/tsung/pull/94 we should reduce the loglevel for issues regarding parsing the current page as XML/HTML when applying XPath expressions for dynvars.

The current problem is, that we generate A LOT of log data when we dump the entire page. It will be printed as binary (`ts_search:(3:<0.3361.0>) Page couldn't be parsed:(error:function_clause) 
 Page:<<72,84,84,80,47,49,46,49,32,50,48,48,33,…>>`).

When we run large-scale load tests, errors on the backend are to be expected. In those cases we end up with log files being multiple hundred MB in size putting quite a bit of stress on tsung nodes impacting the test as a side-effect.

Besides reducing the log level, this PR also adds a new error counter being reported to `ts_mon`: `error_xml_unparsable`. This error is comparable to `error_json_unparsable`.