### PR TITLE
Travis: Test against Erlang 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: erlang
 otp_release:
-   - 20.0
-   - 19.3
-   - 18.3
-   - 17.1
-   - R16B03-1
+   - "21.0"
+   - "20.3"
+   - "19.3"
+   - "18.3"
+   - "17.1"
+   - "R16B03-1"
 script: ./configure && make test
 notifications:
    email: nicolas@niclux.org

--- a/src/test/ts_test_utils.erl
+++ b/src/test/ts_test_utils.erl
@@ -48,7 +48,7 @@ mkey1search_string_test()->
     ?assertEqual(["bar","caps"],ts_utils:mkey1search(Data,"foo")).
 
 datestr_test()->
-    ?assertEqual(["2013",49,48,49,55,45,49,57,52,49],ts_utils:datestr({{2013,10,17},{19,41,29}})).
+    ?assertEqual("20131017-1941",lists:flatten(ts_utils:datestr({{2013,10,17},{19,41,29}}))).
 
 export_text_test()->
     ?assertEqual("foo",ts_utils:export_text("foo")).

--- a/src/test/ts_test_utils.erl
+++ b/src/test/ts_test_utils.erl
@@ -48,7 +48,7 @@ mkey1search_string_test()->
     ?assertEqual(["bar","caps"],ts_utils:mkey1search(Data,"foo")).
 
 datestr_test()->
-    ?assertEqual(["2013","10","17",45,"19","41"],ts_utils:datestr({{2013,10,17},{19,41,29}})).
+    ?assertEqual(["2013",49,48,49,55,45,49,57,52,49],ts_utils:datestr({{2013,10,17},{19,41,29}})).
 
 export_text_test()->
     ?assertEqual("foo",ts_utils:export_text("foo")).


### PR DESCRIPTION
This PR instructs Travis CI also to build against Erlang/OTP 21.

So far I've not done any further testing, but only a small change was required to get it to run tests without issues. The same compiler warnings as already reported in #312 popped up, but beside this, it seems to be fine.

PS: I changed the versions to strings in `.travis.yml`. This way it is unmistakable as a version, and not as a number (e.g. `1.0.0` will be interpreted as `1.0`). This was not an issue, I just wanted to make it more robust.