### PR TITLE
mqtt subscribe packet MUST set qos to 1 for the fixed header

### DIFF
--- a/src/test/ts_test_mqtt.erl
+++ b/src/test/ts_test_mqtt.erl
@@ -113,9 +113,9 @@ decode_publish_test() ->
 
 encode_subscribe_test() ->
     Arg = [#sub{topic = "test_topic", qos = 0}],
-    Message = #mqtt{id = 1, type = ?SUBSCRIBE, arg = Arg},
+    Message = #mqtt{id = 1, type = ?SUBSCRIBE, arg = Arg, qos = 1},
     EncodedData = mqtt_frame:encode(Message),
-    ?assertEqual(<<128,15,0,1,0,10,116,101,115,116,95,116,111,112,105,99,0>>, EncodedData).
+    ?assertEqual(<<130,15,0,1,0,10,116,101,115,116,95,116,111,112,105,99,0>>, EncodedData).
 
 decode_subscribe_test() ->
     Data = <<128,15,0,1,0,10,116,101,115,116,95,116,111,112,105,99,0>>,

--- a/src/tsung/ts_mqtt.erl
+++ b/src/tsung/ts_mqtt.erl
@@ -131,7 +131,7 @@ get_message(#mqtt_request{type = subscribe, topic = Topic, qos = Qos},
     NewMqttSession = MqttSession#mqtt_session{curr_id = Id + 1},
     Arg = [#sub{topic = Topic, qos = Qos}],
     MsgId = NewMqttSession#mqtt_session.curr_id,
-    Message = #mqtt{id = MsgId, type = ?SUBSCRIBE, arg = Arg},
+    Message = #mqtt{id = MsgId, type = ?SUBSCRIBE, arg = Arg, qos = 1},
     {mqtt_frame:encode(Message), NewMqttSession#mqtt_session{wait = ?SUBACK}};
 get_message(#mqtt_request{type = unsubscribe, topic = Topic},
             #state_rcv{session = MqttSession = #mqtt_session{curr_id = Id}}) ->


### PR DESCRIPTION
Hi, I discovered this while testing with VerneMQ. According to the MQTT spec, bits 3,2,1 and 0 of the fixed header of the SUBSCRIBE Control Packet are reserved and MUST be set to 0,0,1 and 0 respectively. Tsung sets these to 0,0,0,0 which causes VerneMQ to drop the connection.

https://docs.solace.com/MQTT-311-Prtl-Conformance-Spec/MQTT%20Control%20Packets.htm#_Toc430864927