### PR TITLE
Fix docs to substitute for-loop counter variable

### DIFF
--- a/docs/conf-advanced-features.rst
+++ b/docs/conf-advanced-features.rst
@@ -632,7 +632,7 @@ requests. List of attributes:
 
  <for from="1" to="10" incr="1" var="counter">
    ...
-   <request> <http url="/page?id=%%_counter%%"></http> </request>
+   <request subst="true"> <http url="/page?id=%%_counter%%"></http> </request>
    ...
  </for>
 


### PR DESCRIPTION
I tried a for-loop example and found out `subst="true"` is needed here.