### PR TITLE
Tsung controller failed to rpc call to remote ts_os_mon_erlang module

### DIFF
--- a/src/tsung_controller/ts_os_mon_erlang.erl
+++ b/src/tsung_controller/ts_os_mon_erlang.erl
@@ -322,7 +322,11 @@ get_os_data(packets, {unix, _}, Data) ->
 %% Purpose: Start an Erlang node on given host
 %%--------------------------------------------------------------------
 start_beam(Host) ->
-    Args = ts_utils:erl_system_args(),
+    {ok, PAList}    = init:get_argument(pa),
+    PA = lists:flatmap(fun(A) -> [" -pa "] ++A end,PAList),
+    ?LOGF("PA list ~p ~n", [PA], ?DEB),
+    Sys_Args = ts_utils:erl_system_args(),
     ?LOGF("Starting os_mon beam on host ~p ~n", [Host], ?NOTICE),
+    Args = lists:flatten([Sys_Args, PA]),
     ?LOGF("~p Args: ~p~n", [Host, Args], ?DEB),
     slave:start(list_to_atom(Host), ?NODE, Args).


### PR DESCRIPTION
Tsung controller failed to rpc call to remote tsung_os_mon_erlang module during the start-up. After enable debug log, I am seeing following errors. 
`=INFO REPORT==== 14-Sep-2018::00:30:15 ===
    ts_os_mon_erlang:(7:<0.144.0>) load_code: [{[{error,badfile}],[]},
                                               {[{error,badfile}],[]},
                                               {[{error,badfile}],[]},
                                               {[{error,badfile}],[]}] start: {[{badrpc,
                                                                                 {'EXIT',
                                                                                  {undef,
                                                                                   [{ts_os_mon_erlang,
                                                                                     client_start,
                                                                                     [],
                                                                                     []},
                                                                                    {rpc,
                                                                                     '-handle_call_call/6-fun-0-',
                                                                                     5,
                                                                                     [{file,
                                                                                       "rpc.erl"},
                                                                                      {line,
                                                                                       206}]}]}}}],
                                                                               []}`

By looking at the slave:start arguments in the debug log.
`=INFO REPORT==== 14-Sep-2018::00:30:14 ===
    ts_os_mon_erlang:(7:<0.144.0>) acme" Args: " -rsh ssh -detached -setcookie  tsung   +S 1     +A 8 +P 262144  -kernel inet_dist_listen_min 64000  -kernel \
inet_dist_listen_max 65500  -ssl session_cb ts_ssl_session_cache  -ssl session_lifetime 600 "`

IMHO, the code path should be added just like remote tsung node during the startup specially if the controller architecture is different from that of client host.