### PR TITLE
Fix waiting for response body on HTTP HEAD requests with Content-Length set

### DIFF
--- a/src/tsung/ts_http_common.erl
+++ b/src/tsung/ts_http_common.erl
@@ -371,6 +371,18 @@ check_resp_size(Http=#http{content_length=CLength, close=Close},
     log_error(Dump, error_http_bad_content_length),
     {State#state_rcv{session= reset_session(Http), ack_done = true,
                      datasize = DataSize }, [], Close};
+
+%% header is complete (partial=false), HTTP Method is HEAD, so we do not
+%% expect any more data
+check_resp_size(Http=#http{partial=false, close=Close},
+    _BodySize,
+    State=#state_rcv{request=#ts_request{param=#http_request{method=head}}},
+    DataSize, _Dump) ->
+
+    {State#state_rcv{session=reset_session(Http), ack_done=true,
+                     datasize=DataSize}, [], Close};
+
+
 check_resp_size(Http=#http{}, BodySize,  State, DataSize,_Dump) ->
     %% need to read more data
     {State#state_rcv{session  = Http#http{body_size = BodySize},


### PR DESCRIPTION
We recently noticed, that tsung will wait on HTTP `HEAD` requests when `Content-Length` header is set to non-zero value.

According to [RFC2616 section 14.13](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13):

> The Content-Length entity-header field indicates the size of the entity-body, in decimal number of OCTETs, sent to the recipient or, **in the case of the HEAD method, the size of the entity-body that would have been sent had the request been a GET.**

So the `Content-Length` header - if present - will contain the expected response size for a non-HEAD request. Actually it is recommended that `Content-Length` should be present (also RFC2616 section 14.13):

> Applications SHOULD use this field to indicate the transfer-length of the message-body, unless this is prohibited by the rules in section 4.4.

So it is considered "normal" that a HTTP HEAD requests contains a `Content-Length` header.

This is the same with HTTP 1.0, according to [RFC1945 Sec 10.4](https://tools.ietf.org/html/rfc1945#section-10.4).

## Issue

The problem in tsung was with `ts_http_common:check_resp_size/4`. If headers are received completely and the content length is non-zero, we always expect more data. This resulted in tsung waiting indefinitely (until server closes connection).

## Solution

In case we have completely read the HTTP headers and in case of the HTTP verb is `HEAD`, we are done reading the response, regardless what `Content-Length` states. In this case we can set `ack_done` in `#state_rcv` to `true`.

The problem can be reproduced using

```xml
<?xml version="1.0"?>
<!DOCTYPE tsung SYSTEM "/tsung/install/share/tsung/tsung-1.0.dtd" []>
<tsung loglevel="debug" dumptraffic="true">
  <clients>
    <client host="localhost" use_controller_vm="true"/>
  </clients>
  <servers>
    <server host="testapp.loadtest.party" port="80" type="tcp"/>
  </servers>
  <load duration="300" unit="second">
    <arrivalphase phase="0" duration="300" unit="second">
      <users maxnumber="1" arrivalrate="1" unit="second" />
    </arrivalphase>
  </load>
  <sessions>
    <session name="http_head" weight="1" type="ts_http">
      <request subst="true">
        <http url="/status/200" method="HEAD" version="1.1">
        </http>
      </request>
    </session>
  </sessions>
</tsung>
```

Note that this host will respond with `Content-Length`:

```console
$ curl --head testapp.loadtest.party
HTTP/1.1 200 OK
Content-Type: text/html
Content-Length: 112
Connection: keep-alive
Status: 200 OK
Date: Sun, 16 Sep 2018 18:08:59 GMT
X-Powered-By: Phusion Passenger 5.3.4
Server: nginx/1.14.0 + Phusion Passenger 5.3.4
```