### PR TITLE
Feature: Support inline TLS Certificates and Keys

### DIFF
--- a/src/tsung/ts_client.erl
+++ b/src/tsung/ts_client.erl
@@ -1072,6 +1072,8 @@ reconnect(none, ServerName, Port, {Protocol, Proto_opts}, {IP,CPort, Try}) when 
                 {{options, {Option, _}}, _, _} ->
                     CountName="error_connect_option_"++atom_to_list(Option),
                     ts_mon_cache:add({ count, list_to_atom(CountName) });
+                {tls_alert, "bad certificate"} ->
+                    ts_mon_cache:add({ count, list_to_atom("error_connect_tls_bad_certificate") });
                 _ ->
                     CountName="error_connect_"++atom_to_list(Reason),
                     ts_mon_cache:add({ count, list_to_atom(CountName) })

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -124,13 +124,15 @@
     type     (ts_http | ts_jabber | ts_pgsql) #IMPLIED
     value    CDATA #IMPLIED>
 
-<!ELEMENT certificate EMPTY >
+<!ELEMENT certificate (cert | key)*>
 <!ATTLIST certificate
     cacertfile  CDATA #IMPLIED
     keyfile     CDATA #IMPLIED
     keypass     CDATA #IMPLIED
     certfile    CDATA #IMPLIED
 >
+<!ELEMENT key (#PCDATA)>
+<!ELEMENT cert (#PCDATA)>
 
 <!ELEMENT sessions (session+)>
 <!ELEMENT session ( request | thinktime | transaction | setdynvars | for |


### PR DESCRIPTION
This PR adds `<cert>` and `<key>` under `<set_option name="certificate">`:

```xml
<set_option name="certificate">
  <certificate>
    <cert>
      <![CDATA[
      -----BEGIN CERTIFICATE-----
      <!-- ... -->
      -----END CERTIFICATE-----
      ]]>
    </cert>
    <key>
      <![CDATA[
      -----BEGIN RSA PRIVATE KEY-----
      <!-- ... -->
      -----END RSA PRIVATE KEY-----
      ]]>
    </key>
  </certificate>
</set_option>
```

Previously it was only possible to provide certificates and keys via files. I need to be able to handle certificates and keys based on dynvar data (e.g. by extracting from responses or using file servers).

## Notes

- **only one certificate and one key is currently supported**
- [x] data has to be provided in PEM encoded format
- [x] `cert` and `key` will be run through `ts_search:subst/2` thus supporting to have dynamic configuration
- [x] New error counter events have been added
  - `error_connect_option_*` if connection options are invalid (happens in certain cases where the provided certificate or key is not valid)
  - `error_connect_tls_bad_certificate` if the provided certificate could not be used