### PR TITLE
Add option to disable SNI for TLS connections

### DIFF
--- a/docs/conf-options.rst
+++ b/docs/conf-options.rst
@@ -9,6 +9,7 @@ Setting options
 .. index:: ssl_ciphers
 .. index:: ssl_versions
 .. index:: ssl_reuse_sessions
+.. index:: ssl_disable_sni
 .. index:: tcp_snd_buffer
 .. index:: tcp_rcv_buffer
 .. index:: udp_snd_buffer
@@ -59,6 +60,15 @@ you manage hundreds of clients, you may want to raise this value with
 .. code-block:: xml
 
  <option name="max_ssh_startup_per_core" value="100"/>
+
+.. versionadded:: 1.8.0
+
+You can disable the Server Name Indication feature of TLS (it is enabled by default).
+
+.. code-block:: xml
+
+ <option name="ssl_disable_sni" value="true"/>
+
 
 
 .. index:: idle_timeout

--- a/include/ts_profile.hrl
+++ b/include/ts_profile.hrl
@@ -74,6 +74,8 @@
          udp_snd_size  = 32768,
          certificate = [],          % for ssl
          reuse_sessions = true,     % for ssl
+         disable_sni = false,       % for ssl, if set to true, {server_name_indication, disable} will be set
+                                    % for ssl:connect to disable TLS SNI extension and hostname verification
          is_first_connect = true   % whether it's the first connection
         }).
 

--- a/src/tsung/ts_ssl.erl
+++ b/src/tsung/ts_ssl.erl
@@ -8,6 +8,9 @@
 -include("ts_config.hrl").
 
 
+protocol_options(Proto=#proto_opts{disable_sni=true}) ->
+    [{server_name_indication, disable}] ++ protocol_options(Proto#proto_opts{disable_sni=false});
+
 protocol_options(Proto=#proto_opts{ip_transparent = true }) ->
     Opts= [{raw,0,19,<<1:32/native>>} ] ++ protocol_options(Proto#proto_opts{ip_transparent=false}),
     ?DebugF("SSL Real opts: ~p ~n", [Opts]),

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -831,6 +831,19 @@ parse(Element = #xmlElement{name=option, attributes=Attrs},
                         true -> % default value, do nothing
                             lists:foldl( fun parse/2, Conf, Element#xmlElement.content)
                         end;
+                "ssl_disable_sni" ->
+                    case getAttr(atom, Attrs, value, false) of
+                        true ->
+                            OldProto = Conf#config.proto_opts,
+                            NewProto = OldProto#proto_opts{disable_sni = true},
+                            lists:foldl(
+                                fun parse/2,
+                                Conf#config{proto_opts=NewProto},
+                                Element#xmlElement.content
+                            );
+                        false ->
+                            lists:foldl(fun parse/2, Conf, Element#xmlElement.content)
+                    end;
                 "seed" ->
                     Seed =  getAttr(integer,Attrs, value, now),
                     lists:foldl( fun parse/2, Conf#config{seed=Seed},


### PR DESCRIPTION
While testing a HTTP-based system using mutual TLS authentication (= client and server TLS certificates) I ran into several issues with Erlang and errors during TLS handshakes when using TLS client certificates. The root cause is not fully understood currently, but the parts of the solution is :)

[Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) is a TLS extension allowing the server to receive a hostname indication the client wishes to connect to.

According to http://erlang.org/doc/man/ssl.html#tls-dtls-option-descriptions---client-side, `{server_name_indication, disable}` can be used to disable SNI:

> `server_name_indication, disable}`
>
> Prevents the Server Name Indication extension from being sent and disables the hostname verification check

This PR introduces the following option:

```xml
<options>
  <option name="ssl_disable_sni" value="true" />
</options>
```
