### PR TITLE
Add max channels config

### DIFF
--- a/examples/amqp.xml.in
+++ b/examples/amqp.xml.in
@@ -29,7 +29,7 @@
 	<sessions>
 		<session probability="100" name="amqp_publisher" type="ts_amqp" bidi="true">
             <request>
-                <amqp type="connection.open" vhost="/"></amqp>
+                <amqp type="connection.open" vhost="/" channel_max="2047"></amqp>
             </request>
 
             <!--  open channel, channel id is from 1 to 10 -->
@@ -78,7 +78,7 @@
 		</session>
 		<session probability="0" name="amqp_consumer" type="ts_amqp" bidi="true">
             <request>
-                <amqp type="connection.open"></amqp>
+                <amqp type="connection.open" channel_max="2047"></amqp>
             </request>
 
             <for from="1" to="10" incr="1" var="loops">

--- a/include/ts_amqp.hrl
+++ b/include/ts_amqp.hrl
@@ -57,7 +57,8 @@
           payload,
           payload_size,
           queue,
-          ack
+          ack,
+          channel_max
          }).
 
 -record(amqp_dyndata, { 

--- a/src/tsung/ts_amqp.erl
+++ b/src/tsung/ts_amqp.erl
@@ -103,13 +103,12 @@ get_message1(#amqp_request{type = 'connection.start_ok', username = UserName,
     Waiting = {0, 'connection.tune'},
     {Frame, AMQPSession#amqp_session{waiting = Waiting}};
 
-get_message1(#amqp_request{type = 'connection.tune_ok', heartbeat = HeartBeat},
+get_message1(#amqp_request{type = 'connection.tune_ok', heartbeat = HeartBeat, channel_max = ChannelMax},
             #state_rcv{session = AMQPSession}) ->
     Protocol = AMQPSession#amqp_session.protocol,
-
-    Tune = #'connection.tune_ok'{frame_max = 131072, heartbeat = HeartBeat},
+    Tune = #'connection.tune_ok'{channel_max = ChannelMax, frame_max = 131072, heartbeat = HeartBeat},
     Frame = assemble_frame(0, Tune, Protocol),
-    {Frame, AMQPSession#amqp_session{waiting = none}};
+    {Frame, AMQPSession#amqp_session{waiting = none, channel_max = ChannelMax}};
 
 get_message1(#amqp_request{type = 'connection.open', vhost = VHost},
             #state_rcv{session = AMQPSession}) ->

--- a/src/tsung_controller/ts_config_amqp.erl
+++ b/src/tsung_controller/ts_config_amqp.erl
@@ -135,9 +135,10 @@ parse_request(_Element, Type = 'connection.start_ok', Tab) ->
     Request = #amqp_request{type = Type, username = UserName,
                             password = Password},
     {parse, Request};
-parse_request(_Element, Type = 'connection.tune_ok', Tab) ->
+parse_request(Element, Type = 'connection.tune_ok', Tab) ->
     HeartBeat = ts_config:get_default(Tab, amqp_heartbeat),
-    Request = #amqp_request{type = Type, heartbeat = HeartBeat},
+    ChannelMax = ts_config:getAttr(float_or_integer, Element#xmlElement.attributes, channel_max, 0),
+    Request = #amqp_request{type = Type, heartbeat = HeartBeat, channel_max = ChannelMax},
     {no_ack, Request};
 parse_request(Element, Type = 'channel.open', _Tab) ->
     Channel = ts_config:getAttr(string, Element#xmlElement.attributes,

--- a/tsung-1.0.dtd
+++ b/tsung-1.0.dtd
@@ -397,7 +397,8 @@ repeat | if | change_type | foreach | set_option | interaction | abort )*>
     persistent CDATA "false"
     queue CDATA ""
     timeout CDATA "1"
-    ack CDATA "false" >
+    ack CDATA "false"
+    channel_max CDATA "0" >
 
 <!ELEMENT mqtt (#PCDATA) >
 <!ATTLIST mqtt


### PR DESCRIPTION
If you setup rabbitmq with the default configuration the amqp plugin won't be able to tune the connection and the load test script will fail. The default was add in https://github.com/rabbitmq/rabbitmq-server/issues/1593.

With this change we are able to configure the max channels for the connection.

```xml
<amqp type="connection.open" vhost="/" channel_max="2047"></amqp>
```
