### PR TITLE
Add websocket_origin parameters to customize Origin header

### DIFF
--- a/include/ts_profile.hrl
+++ b/include/ts_profile.hrl
@@ -62,6 +62,7 @@
          ip_transparent = false,  % set IP_TRANSPARENT option on the socket
          websocket_path = "/chat",  % for websocket only
          websocket_frame = "binary",  % for websocket only
+         websocket_origin = "",  % for websocket only
          websocket_subprotocols = [],     % for websocket only
          retry_timeout = 10,        % retry sending in milliseconds
          max_retries = 3,           % maximum number of retries
@@ -96,6 +97,7 @@
          retries=0,   % number of connect retries
          hibernate = 10000, % hibernate if thinktime is >= to this (10sec by default)
          host,        % hostname (or IP) of remote server
+         origin,      % Origin Header
          port,        % server port
          protocol,    % gen_udp, gen_tcp or ssl
          proto_opts = #proto_opts{},  %

--- a/src/tsung_controller/ts_config.erl
+++ b/src/tsung_controller/ts_config.erl
@@ -950,6 +950,12 @@ parse(Element = #xmlElement{name=option, attributes=Attrs},
                     NewProto =  OldProto#proto_opts{websocket_subprotocols=SubProtocols},
                     lists:foldl( fun parse/2, Conf#config{proto_opts=NewProto},
                                  Element#xmlElement.content);
+               "websocket_origin" ->
+                   Origin = getAttr(string,Attrs, value, ?config(websocket_origin)),
+                   OldProto =  Conf#config.proto_opts,
+                   NewProto =  OldProto#proto_opts{websocket_origin=Origin},
+                   lists:foldl( fun parse/2, Conf#config{proto_opts=NewProto},
+                                Element#xmlElement.content);
                 "bosh_path" ->
                     Path = getAttr(string,Attrs, value, ?config(bosh_path)),
                     OldProto =  Conf#config.proto_opts,


### PR DESCRIPTION
Add websocket_origin parameters to customize Origin header for xmpp websocket connection.
This Headers is useful to test XMPP server like Prosody. 

Exemple usage in test script : 
`    <option type="ts_jabber" name="muc_service" value="conference.XMPPSERVER"/>`
 `   <option name="websocket_origin" `value="https://XXXXXXXX"/>`
 `   <option name="websocket_frame" value="text"/>`
 `   <option type="ts_http" name="user_agent">`
 `   <user_agent `probability="100">`


