### PR TITLE
Improve docs: Add links to apache benchmark

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,5 +1,6 @@
 .. index:: faq
 .. _faq:
+.. _ab: http://httpd.apache.org/docs/current/programs/ab.html
 
 ==========================
 Frequently Asked Questions
@@ -327,7 +328,7 @@ How can i simulate a fix number of users?
 =========================================
 
 Use ``maxnumber`` to set the max number of concurrent users in a
-phase, and if you want Tsung to behave like ab, you can use a loop
+phase, and if you want Tsung to behave like ab_, you can use a loop
 in a session (to send requests as fast as possible); you can also define a
 max ``duration`` in ``<load>``.
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1,3 +1,5 @@
+.. _ab: http://httpd.apache.org/docs/current/programs/ab.html
+
 ========
 Features
 ========
@@ -12,7 +14,7 @@ Tsung main features
   active: it can be idle during a ``thinktime``
   period). Traditional injection tools can hardly go further than a 
   few hundreds (Hint: if all you want to do is requesting a single URL
-  in a loop, use :program:`ab`; but if you want to build complex
+  in a loop, use ab_; but if you want to build complex
   scenarios with extended reports, ``Tsung`` is for you).
 
 * *Distributed*: the load can be distributed on a cluster of client machines


### PR DESCRIPTION
I am new to last testing. Thus is stumbled when reading "ab" in the docs. Eventually when seeing it the second time I did start googling what it is. Adding link to docs is meant to help others to learn more easily. 