### PR TITLE
replace httpd_util functions removed in OTP26

### DIFF
--- a/src/tsung/ts_digest.erl
+++ b/src/tsung/ts_digest.erl
@@ -72,13 +72,13 @@ shahex(Clear) ->
 %%%----------------------------------------------------------------------
 tohex(A)->
     Fun = fun(X)->
-                  ts_utils:to_lower(padhex(httpd_util:integer_to_hexlist(X)))
+                  ts_utils:to_lower(padhex(erlang:integer_to_list(X, 16)))
           end,
     lists:flatten( lists:map(Fun, A) ).
 
 %%%----------------------------------------------------------------------
 %%% Func: padhex/1
-%%% Purpose: needed because httpd_util:integer_to_hexlist returns hex
+%%% Purpose: needed because erlang:integer_to_list(X, 16) returns hex
 %%%    values <10 as only 1 character, ie. "0F" is simply returned as
 %%%    "F". For our digest, we need these leading zeros to be present.
 %%% ----------------------------------------------------------------------

--- a/src/tsung/ts_http.erl
+++ b/src/tsung/ts_http.erl
@@ -315,7 +315,7 @@ decode_chunk_size(<<Head:2/binary, Data/binary >>, Headers, Body, <<>>) when Hea
     ?Debug("decode chunk: crlf, no digit"),
     decode_chunk_size(Data, Headers, Body, <<>>);
 decode_chunk_size(<<Head:2/binary, Data/binary >>, Headers, Body,Digits) when Head ==  << "\r\n" >> ->
-    case httpd_util:hexlist_to_integer(binary_to_list(Digits)) of
+    case erlang:list_to_integer(binary_to_list(Digits), 16) of
         0 ->
             decode_chunk_size(Data, Headers, Body ,<<>>);
         Size ->

--- a/src/tsung/ts_http_common.erl
+++ b/src/tsung/ts_http_common.erl
@@ -405,7 +405,7 @@ parse_chunked(Body, State)->
 %%----------------------------------------------------------------------
 read_chunk(<<>>, State, Int, Acc) ->
     ?LOGF("No data in chunk [Int=~p, Acc=~p] ~n", [Int,Acc],?INFO),
-    AccInt = list_to_binary(httpd_util:integer_to_hexlist(Int)),
+    AccInt = list_to_binary(erlang:integer_to_list(Int, 16)),
     { State#state_rcv{acc = AccInt, ack_done = false }, [] }; % read more data
 %% this code has been inspired by inets/http_lib.erl
 %% Extensions not implemented


### PR DESCRIPTION
See details [here](https://www.erlang.org/doc/general_info/removed), the removed functions were replaced by proposed erlang functions which existed since very early releases and had the same behavior (I tested that

```erlang
%%%    ... erlang:integer_to_list(X, 16) returns hex
%%%    values <10 as only 1 character, ie. "0F" is simply returned as
%%%    "F"* ...
```

), so the change must be ok with older OTP versions too.

On my Fedora 39 with OTP 26 sessions that contain `apply_to_content='ts_digest:md5hex'` break with

```
** Reason for termination ==
** {'function not exported',
       [{httpd_util,integer_to_hexlist,"Ô",[]},
        {ts_digest,'-tohex/1-fun-0-',1,
            [{file,"src/tsung/ts_digest.erl"},{line,75}]},
        {lists,map,2,[{file,"lists.erl"},{line,1559}]},
        {ts_digest,tohex,1,[{file,"src/tsung/ts_digest.erl"},{line,77}]},
        {ts_search,match,5,[{file,"src/tsung/ts_search.erl"},{line,142}]},
        {ts_client,handle_data_msg,2,
            [{file,"src/tsung/ts_client.erl"},{line,1150}]},
        {ts_client,handle_info2,3,
            [{file,"src/tsung/ts_client.erl"},{line,251}]},
        {gen_fsm,handle_msg,8,[{file,"gen_fsm.erl"},{line,475}]}]}
```

(in tsung installed by dnf), and worse, it hugely leaks memory. If I compile tsung from source, I get

```ShellSession
$ make
Compiling  src/tsung/ts_digest.erl ... 
src/tsung/ts_digest.erl:75:44: Warning: httpd_util:integer_to_hexlist/1 is removed; use erlang:integer_to_list/2 with base 16 instead
%   75|                   ts_utils:to_lower(padhex(httpd_util:integer_to_hexlist(X)))
%     |                                            ^
```

This patch fixes the memory leak and the build.