### PR TITLE
Replaced calls to `random` by `rand`

### DIFF
--- a/src/lib/uuid.erl
+++ b/src/lib/uuid.erl
@@ -53,10 +53,10 @@ random_str() ->
 %%
 random() ->
     U = <<
-        (random:uniform(4294967296) - 1):32,
-        (random:uniform(4294967296) - 1):32,
-        (random:uniform(4294967296) - 1):32,
-        (random:uniform(4294967296) - 1):32
+        (rand:uniform(4294967296) - 1):32,
+        (rand:uniform(4294967296) - 1):32,
+        (rand:uniform(4294967296) - 1):32,
+        (rand:uniform(4294967296) - 1):32
     >>,
     format_uuid(U, 4).
 
@@ -66,7 +66,7 @@ random() ->
 %%
 srandom() ->
     {A1,A2,A3} = erlang:now(),
-    random:seed(A1, A2, A3),
+    rand:seed(A1, A2, A3),
     random().
 
 %% @spec sha(Namespace, Name) -> uuid()
@@ -150,10 +150,10 @@ stop() ->
 
 init(Options) ->
     {A1,A2,A3} = proplists:get_value(seed, Options, erlang:now()),
-    random:seed(A1, A2, A3),
+    rand:seed(A1, A2, A3),
     State = #state{
         node = proplists:get_value(node, Options, <<0:48>>),
-        clock_seq = random:uniform(65536)
+        clock_seq = rand:uniform(65536)
     },
     error_logger:info_report("uuid server started"),
     {ok, State}.

--- a/src/lib/websocket.erl
+++ b/src/lib/websocket.erl
@@ -131,7 +131,7 @@ decode(Data) ->
 %%% Internal functions
 %%%===================================================================
 gen_accept_key() ->
-    random:seed(erlang:now()),
+    rand:seed(erlang:now()),
     Key = crypto:strong_rand_bytes(16),
     KeyStr = base64:encode_to_string(Key),
     Accept = binary:list_to_bin(KeyStr ++ "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"),

--- a/src/test/ts_test_config.erl
+++ b/src/test/ts_test_config.erl
@@ -122,7 +122,7 @@ config_thinktime2_test() ->
     receive
         {timeout,Ref2,end_thinktime} -> ok
     end,
-    random:seed(), % reinit seed for others tests
+    rand:seed(), % reinit seed for others tests
     ?assertMatch({random,1000}, Req).
 
 read_config_tag_noexclusion_test() ->

--- a/src/tsung/ts_bosh.erl
+++ b/src/tsung/ts_bosh.erl
@@ -276,7 +276,7 @@ do_receive_http_response(State, Socket, Vsn) ->
 
 do_connect(#state{type = Type, host = Host, path = Path, parent_pid = ParentPid} = State, Domain) ->
     ?DebugF("do_connect ~p",[State]),
-    Rid = 1000 + random:uniform(100000),
+    Rid = 1000 + rand:uniform(100000),
     %%Port= proplists:get_value(local_port, Options, undefined),
     NewState = State#state{
             domain = Domain,

--- a/src/tsung/ts_cport.erl
+++ b/src/tsung/ts_cport.erl
@@ -77,7 +77,7 @@ init([]) ->
     {Min, Max} = {?config(cport_min),?config(cport_max)},
     ts_utils:init_seed(),
     %% set random port for the initial value.
-    case catch Min+random:uniform(Max-Min) of
+    case catch Min+rand:uniform(Max-Min) of
         Val when is_integer(Val) ->
             ?LOGF("Ok, starting with ~p value~n",[Val],?NOTICE),
             {ok, #state{min_port=Min, max_port=Max}};

--- a/src/tsung/ts_launcher.erl
+++ b/src/tsung/ts_launcher.erl
@@ -224,7 +224,7 @@ launcher(timeout, State=#launcher{nusers        = Users,
             end;
         error ->
             % retry with the next user, wait randomly a few msec
-            RndWait = random:uniform(?NEXT_AFTER_FAILED_TIMEOUT),
+            RndWait = rand:uniform(?NEXT_AFTER_FAILED_TIMEOUT),
             {next_state,launcher,State#launcher{nusers = Users-1} , RndWait}
     end.
 

--- a/src/tsung/ts_session_cache.erl
+++ b/src/tsung/ts_session_cache.erl
@@ -197,7 +197,7 @@ code_change(_OldVsn, State, _Extra) ->
 choose_user_agent(empty) -> {ok, "tsung"};
 choose_user_agent([{_P, Val}]) -> {ok, Val};
 choose_user_agent(UserAgents) ->
-    choose_user_agent(UserAgents, random:uniform(100),0).
+    choose_user_agent(UserAgents, rand:uniform(100),0).
 
 choose_user_agent([{P, Val} | _],Rand, Cur) when Rand =< P+Cur->
     {ok, Val};

--- a/src/tsung/ts_stats.erl
+++ b/src/tsung/ts_stats.erl
@@ -55,11 +55,11 @@ sample (F, X, Param, N) ->
     sample(F, [F(Param)|X], Param, N-1 ).
 
 uniform(Min,Max)->
-    Min+random:uniform(Max-Min+1)-1.
+    Min+rand:uniform(Max-Min+1)-1.
 
 %% random sample from an exponential distribution
 exponential(Param) ->
-    -math:log(random:uniform())/Param.
+    -math:log(rand:uniform())/Param.
 
 %% N samples from an exponential distribution
 exponential(Param, N) ->
@@ -67,7 +67,7 @@ exponential(Param, N) ->
 
 %% random sample from a Pareto distribution
 pareto(#pareto{a=A, beta=Beta}) ->
-    A/(math:pow(random:uniform(), 1/Beta)).
+    A/(math:pow(rand:uniform(), 1/Beta)).
 
 %% if a list is given, construct a record for the parameters
 pareto([A, Beta], N) ->
@@ -86,7 +86,7 @@ invgaussian(Param,N) ->
 invgaussian(#invgaussian{mu=Mu, lambda=Lambda}) ->
     Y = Mu*pow(normal(), 2),
     X1 = Mu+Mu*Y/(2*Lambda)-Mu*sqrt(4*Lambda*Y+pow(Y,2))/(2*Lambda),
-    U = random:uniform(),
+    U = rand:uniform(),
     X = (Mu/(Mu+X1))-U,
     case X >=0 of
         true  -> X1;
@@ -114,8 +114,8 @@ normal_boxm(M,S,X1,_X2,W) when W < 1->
     Y1 = X1 * W2,
     M + Y1 * S;
 normal_boxm(M,S,_,_,_W) ->
-    X1 = 2.0 * random:uniform() - 1.0,
-    X2 = 2.0 * random:uniform() - 1.0,
+    X1 = 2.0 * rand:uniform() - 1.0,
+    X2 = 2.0 * rand:uniform() - 1.0,
     normal_boxm(M,S,X1,X2,X1 * X1 + X2 * X2).
 %%%
 

--- a/src/tsung/ts_utils.erl
+++ b/src/tsung/ts_utils.erl
@@ -162,7 +162,7 @@ init_seed(A) when is_integer(A)->
     %% node to set a reproductible but different seed for each launcher.
     Id=get_node_id(),
     ?DebugF("Seeding with ~p on node ~p~n",[Id,node()]),
-    random:seed(1000*Id,-1000*A*Id,1000*A*A);
+    rand:seed(1000*Id,-1000*A*Id,1000*A*A);
 init_seed({A,B}) when is_integer(A) and is_integer(B)->
     Id=get_node_id(),
     ?DebugF("Seeding with ~p ~p ~p on node ~p~n",[A,B,Id,node()]),
@@ -171,9 +171,9 @@ init_seed({A,B}) when is_integer(A) and is_integer(B)->
     %% initial pseudo random values will be quite closed to each
     %% other. Trying to avoid this by using a multiplier big enough
     %% (because the algorithm use mod 30XXX , see random.erl).
-    random:seed(4000*A*B*Id,-4000*B*A*Id,4000*Id*Id*A);
+    rand:seed(4000*A*B*Id,-4000*B*A*Id,4000*Id*Id*A);
 init_seed({A,B,C}) ->
-    random:seed(A,B,C).
+    rand:seed(A,B,C).
 
 get_node_id() ->
     case string:tokens(atom_to_list(node()),"@") of
@@ -762,12 +762,12 @@ urandomstr(Size) when is_integer(Size), Size >= 0 ->
 %% @end
 %%----------------------------------------------------------------------
 randomstr(Size) when is_integer(Size), Size >= 0 ->
-     lists:map(fun (_) -> random:uniform(25) + $a  end, lists:seq(1,Size)).
+     lists:map(fun (_) -> rand:uniform(25) + $a  end, lists:seq(1,Size)).
 
 random_alphanumstr(Size) when is_integer(Size), Size >= 0 ->
     AllowedChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
     S = length(AllowedChars),
-    lists:map(fun (_) -> lists:nth(random:uniform(S), AllowedChars) end, lists:seq(1,Size)).
+    lists:map(fun (_) -> lists:nth(rand:uniform(S), AllowedChars) end, lists:seq(1,Size)).
 
 %%----------------------------------------------------------------------
 %% @spec randombinstr(Size::integer()) ->binary()
@@ -779,7 +779,7 @@ randombinstr(Size) when is_integer(Size), Size > 0 ->
     randombinstr(Size,<<>>).
 randombinstr(0,Bin) -> Bin;
 randombinstr(Size,Bin) ->
-    C=random:uniform(25)+$a,
+    C=rand:uniform(25)+$a,
     randombinstr(Size-1, << Bin/binary, C >>).
 
 

--- a/src/tsung_controller/ts_config_server.erl
+++ b/src/tsung_controller/ts_config_server.erl
@@ -600,7 +600,7 @@ choose_client_ip(#client{iprange = {A,B,C,D}}) ->
 choose_server([Server], _TotalWeight) ->
     {ok, Server};
 choose_server(Servers, Total) ->
-    choose_server(Servers, random:uniform() * Total, 0).
+    choose_server(Servers, rand:uniform() * Total, 0).
 
 choose_server([S=#server{weight=P} | _],Rand,Cur) when Rand =< P+Cur->
     {ok, S};
@@ -637,9 +637,9 @@ choose_rr(List, Key, _) ->
 choose_session([Session], _Total, _PhaseId) -> %% only one Session
     {ok, Session};
 choose_session(Sessions,Total,PhaseId) when is_number(Total)->
-    choose_session(Sessions, random:uniform() * Total, 0, PhaseId);
+    choose_session(Sessions, rand:uniform() * Total, 0, PhaseId);
 choose_session(Sessions,Total,PhaseId) when is_list(Total) ->
-    choose_session(Sessions, random:uniform() * lists:nth(PhaseId, Total), 0, PhaseId).
+    choose_session(Sessions, rand:uniform() * lists:nth(PhaseId, Total), 0, PhaseId).
 
 choose_session([S=#session{popularity=P} | _],Rand,Cur,_PhaseId) when is_number(P) andalso Rand =< P+Cur->
     {ok, S};

--- a/src/tsung_controller/ts_file_server.erl
+++ b/src/tsung_controller/ts_file_server.erl
@@ -151,7 +151,7 @@ handle_call({get_all_lines, FileID}, _From, State) ->
 
 handle_call({get_random_line, FileID}, _From, State) ->
     FileDesc = ?DICT:fetch(FileID, State#state.files),
-    I = random:uniform(FileDesc#file.size),
+    I = rand:uniform(FileDesc#file.size),
     Reply = {ok, element(I, FileDesc#file.items)},
     {reply, Reply, State};
 

--- a/src/tsung_controller/ts_local_file_server.erl
+++ b/src/tsung_controller/ts_local_file_server.erl
@@ -110,7 +110,7 @@ init(Lines) ->
 %%          {stop, Reason, State}            (terminate/2 is called)
 %%----------------------------------------------------------------------
 handle_call({get_random_line}, _From, State) ->
-    I = random:uniform(State#file.size),
+    I = rand:uniform(State#file.size),
     Reply = {ok, element(I, State#file.items)},
     {reply, Reply, State};
 

--- a/src/tsung_controller/ts_user_server.erl
+++ b/src/tsung_controller/ts_user_server.erl
@@ -277,7 +277,7 @@ handle_call(get_id, _From, State=#state{userid_max = 0}) ->
     % no user defined in the pool, probably we are using usernames from external file (CSV)
     {reply, {error, userid_max_zero }, State};
 handle_call(get_id, _From, State) ->
-    Key = random:uniform( State#state.userid_max ),
+    Key = rand:uniform( State#state.userid_max ),
     {reply, Key, State};
 
 %%Get one id in the users whose have to be connected


### PR DESCRIPTION
Hello committers,

Thanks for maintaining this project. I would like to bring back to the community, and also to improve my Erlang skills.

Here is the first of few PRs on clearing out compilation warnings. For this one, [`random` is deprecated since Erlang/OTP 19](https://www.erlang.org/doc/deprecations.html#functions-deprecated-in-otp-19).

Thank you,