### PR TITLE
replace deprecated `snmpm:sync_get/4` by `snmpm:sync_get2/4`

### DIFF
--- a/src/tsung_controller/ts_os_mon_snmp.erl
+++ b/src/tsung_controller/ts_os_mon_snmp.erl
@@ -242,7 +242,7 @@ snmp_get("snmp://"++Host, [], State, _TimeOut, Results )->
     analyse_snmp_data(Results,Agent,State);
 snmp_get(URI, [OIDs|Tail], State, TimeOut,PrevRes)->
     ?LOGF("Running snmp get ~p ~p~n", [URI,OIDs], ?DEB),
-    Res = snmpm:sync_get("tsung",URI,OIDs,TimeOut),
+    Res = snmpm:sync_get2("tsung",URI,OIDs,TimeOut),
     ?LOGF("Res ~p ~n", [Res], ?DEB),
     case Res of
         {ok,{noError,_,Results},_Remaining} ->


### PR DESCRIPTION
[`snmpm:sync_get/4` is schedulled for removal in OTP 25](https://www.erlang.org/docs/24/general_info/scheduled_for_removal#otp-25).