### PR TITLE
ts_utils.erl: Fix calls to rand:seed

### DIFF
--- a/src/tsung/ts_utils.erl
+++ b/src/tsung/ts_utils.erl
@@ -162,7 +162,7 @@ init_seed(A) when is_integer(A)->
     %% node to set a reproductible but different seed for each launcher.
     Id=get_node_id(),
     ?DebugF("Seeding with ~p on node ~p~n",[Id,node()]),
-    rand:seed(1000*Id,-1000*A*Id,1000*A*A);
+    rand:seed(default, {1000*Id,-1000*A*Id,1000*A*A});
 init_seed({A,B}) when is_integer(A) and is_integer(B)->
     Id=get_node_id(),
     ?DebugF("Seeding with ~p ~p ~p on node ~p~n",[A,B,Id,node()]),
@@ -171,9 +171,9 @@ init_seed({A,B}) when is_integer(A) and is_integer(B)->
     %% initial pseudo random values will be quite closed to each
     %% other. Trying to avoid this by using a multiplier big enough
     %% (because the algorithm use mod 30XXX , see random.erl).
-    rand:seed(4000*A*B*Id,-4000*B*A*Id,4000*Id*Id*A);
+    rand:seed(default, {4000*A*B*Id,-4000*B*A*Id,4000*Id*Id*A});
 init_seed({A,B,C}) ->
-    rand:seed(A,B,C).
+    rand:seed(default, {A,B,C}).
 
 get_node_id() ->
     case string:tokens(atom_to_list(node()),"@") of


### PR DESCRIPTION
PR https://github.com/processone/tsung/pull/414 fixed compilation warnings but broke tsung at runtime.

See https://www.erlang.org/docs/25/man/rand#seed-2